### PR TITLE
Fix install method for doc dependencies in .readthedocs.yml

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,6 +17,9 @@ build:
     # golang: "1.20"
   jobs:
     install:
+      # Update pip before installing the dependency group
+      # to ensure the --group option actually exists
+      - pip install --upgrade pip 
       - pip install --group docs .
 
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,9 @@ build:
     # nodejs: "20"
     # rust: "1.70"
     # golang: "1.20"
+  jobs:
+    install:
+      - pip install --group docs .
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -28,13 +31,3 @@ sphinx:
 # formats:
 #   - pdf
 #   - epub
-
-# Optional but recommended, declare the Python requirements required
-# to build your documentation
-# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs


### PR DESCRIPTION
Fixes the ReadTheDocs build by changing the install method of the `docs` dependencies in `.readthedocs.yml`. Closes #92.