### PR TITLE
Rename inel_cross_section to prod_cross_section

### DIFF
--- a/changes/159.api.md
+++ b/changes/159.api.md
@@ -1,0 +1,3 @@
+Renamed ``MCEqParticle.inel_cross_section()`` to ``prod_cross_section()`` and
+updated all docstrings to say "production" instead of "inelastic", reflecting
+that the database now provides production cross-sections.

--- a/src/MCEq/core.py
+++ b/src/MCEq/core.py
@@ -1296,7 +1296,7 @@ class MCEqRun:
         zfac = np.zeros(self.dim)
 
         smat = proj.hadr_yields[sec]
-        proj_cs = proj.inel_cross_section()
+        proj_cs = proj.prod_cross_section()
         zfac = np.zeros_like(self.e_grid)
 
         if config.has_cuda:

--- a/src/MCEq/data.py
+++ b/src/MCEq/data.py
@@ -1016,8 +1016,8 @@ class InteractionCrossSections:
         self.index_d = index["index_d"]
 
     def get_cs(self, parent, mbarn=False):
-        """Returns inelastic ``parent``-air cross-section
-        :math:`\\sigma_{inel}^{proj-Air}(E)` as vector spanned over
+        """Returns production ``parent``-air cross-section
+        :math:`\\sigma_{prod}^{proj-Air}(E)` as vector spanned over
         the energy grid.
 
         Args:

--- a/src/MCEq/particlemanager.py
+++ b/src/MCEq/particlemanager.py
@@ -404,13 +404,13 @@ class MCEqParticle:
         except ZeroDivisionError:
             return np.ones_like(self._energy_grid.d) * np.inf
 
-    def inel_cross_section(self, mbarn=False):
-        """Returns inelastic cross section.
+    def prod_cross_section(self, mbarn=False):
+        """Returns production cross section.
 
         Args:
           mbarn (bool) : if True cross section in mb otherwise in cm**2
         Returns:
-          (float): :math:`\\sigma_{\\rm inel}` in mb or cm**2
+          (float): :math:`\\sigma_{\\rm prod}` in mb or cm**2
         """
         #: unit - :math:`\text{GeV} \cdot \text{fm}`
         GeVfm = 0.19732696312541853
@@ -843,7 +843,7 @@ class ParticleManager:
         self.print_particle_tables(10)
 
     def set_cross_sections_db(self, cs_db):
-        """Sets the inelastic cross section to each interacting particle.
+        """Sets the production cross section to each interacting particle.
 
         This applies to most of the hadrons and does not imply that the
         particle becomes a projectile. parents need in addition defined


### PR DESCRIPTION
## Summary
- Renamed `MCEqParticle.inel_cross_section()` → `prod_cross_section()` to reflect that the database now stores production cross-sections
- Updated the call site in `MCEqRun.z_factor()`
- Updated docstrings in `InteractionCrossSections.get_cs()` and `ParticleManager.set_cross_sections_db()`
- Updated Sphinx API docs for `MCEqParticle`

## Test plan
- [x] All pre-commit hooks pass (ruff check, ruff format)
- [x] `pytest tests/ -x` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)