### PR TITLE
Stage CI so platform breakage fails in minutes, not hours

### DIFF
--- a/.github/workflows/_run_tests.yml
+++ b/.github/workflows/_run_tests.yml
@@ -1,0 +1,64 @@
+name: Run test suite
+
+# Single definition of "install MCEq and run the test suite on one platform",
+# called by test.yaml for both the quick gate and the full matrix so the two
+# cannot drift apart.
+
+on:
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+      python-version:
+        required: true
+        type: string
+      upload-coverage:
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  test:
+    runs-on: ${{ inputs.os }}
+    env:
+      UV_SYSTEM_PYTHON: "true"
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        submodules: False
+        fetch-depth: 3
+    - uses: hendrikmuhs/ccache-action@v1.2
+      with:
+        key: test-${{ inputs.os }}-${{ inputs.python-version }}
+    - uses: astral-sh/setup-uv@v7
+    - uses: actions/setup-python@v7
+      with:
+        python-version: ${{ inputs.python-version }}
+        allow-prereleases: true
+    - name: Install requirements
+      run: uv pip install -e . --group test ${{ (runner.os != 'macOS' && runner.arch != 'ARM64') && 'mkl' || '' }}
+    - name: Check MKL version
+      if: runner.os != 'macOS' && runner.arch != 'ARM64'
+      run: pip show mkl
+    - name: Cache test database
+      id: cache-db
+      uses: actions/cache@v6
+      with:
+        path: src/MCEq/data/mceq_db_v140reduced_compact.h5
+        key: mceq-test-db-v1-${{ runner.os }}
+
+    - name: Download test database if not cached
+      if: steps.cache-db.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -L https://github.com/mceq-project/MCEq/releases/download/ci-assets/mceq_db_v140reduced_compact.h5 -o src/MCEq/data/mceq_db_v140reduced_compact.h5
+    - name: Run tests
+      run: pytest --cov=MCEq --cov-branch --cov-report=xml -n 3 --dist loadgroup
+    - name: Upload coverage reports to Codecov
+      if: inputs.upload-coverage
+      uses: codecov/codecov-action@v7
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{ inputs.os }}

--- a/.github/workflows/python_build_test_publish.yml
+++ b/.github/workflows/python_build_test_publish.yml
@@ -10,9 +10,14 @@ on:
   pull_request:
     paths:
       - '.github/workflows/python_build_test_publish.yml'
+      - 'CMakeLists.txt'
+      - 'pyproject.toml'
+      - 'src/**'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  # head_ref is empty for push and tag events, so without the run_id fallback
+  # every push to main cancels the release run of the previous one.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
@@ -35,10 +40,16 @@ jobs:
             echo "should_release=false" >> $GITHUB_OUTPUT
           fi
 
-  test_pr:
-    name: Test Building Wheels on PR with Python 3.14
-    if: github.event_name == 'pull_request'
+  # One Python per platform, ~2 min a job. Anything that breaks the toolchain on
+  # a platform -- a compiler that is not found, a wheel the repair step refuses,
+  # a deployment target that no longer matches the runner image -- fails here
+  # instead of somewhere inside the 46-job release matrix. Runs on PRs that
+  # touch the build, and gates `wheels` on push so a bad platform costs one
+  # round of six jobs rather than the whole matrix.
+  smoke:
+    name: Wheel smoke test (Python 3.14)
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -57,9 +68,13 @@ jobs:
 
   wheels:
     name: Building Wheels
-    needs: release_check
+    needs: [release_check, smoke]
     if: needs.release_check.outputs.should_release == 'true'
     runs-on: ${{ matrix.os }}
+    # No wheel job in this matrix has ever needed more than ~2.5 min. Without a
+    # bound, a runner that loses contact with the server (as macos-26-intel /
+    # cp314 did in run 31360781445) sits on the 6 h default before failing.
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -95,6 +110,7 @@ jobs:
     if: needs.release_check.outputs.should_release == 'true'
     name: source package
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,64 +11,51 @@ on:
       - pyproject.toml
       - CMakeLists.txt
       - .github/workflows/test.yaml
+      - .github/workflows/_run_tests.yml
   push:
     branches:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  # head_ref is empty for push, tag and schedule events, so without the run_id
+  # fallback every push to main cancels the previous run.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
+  # Stage 1: one platform, one Python. A plain Python error, a broken import or
+  # a failing test shows up here after one job instead of after 46, most of them
+  # on the billing-multiplied macOS and Windows runners.
+  quick:
+    name: quick (ubuntu-latest, 3.12)
+    uses: ./.github/workflows/_run_tests.yml
+    secrets: inherit
+    with:
+      os: ubuntu-latest
+      python-version: "3.12"
+
+  # Stage 2: everything else, only once the quick gate is green.
   test:
-    runs-on: ${{ matrix.os }}
-    env:
-      UV_SYSTEM_PYTHON: "true"
+    needs: quick
+    name: ${{ matrix.os }} ${{ matrix.python-version }}
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-26, macos-latest, macos-15-intel, macos-26-intel, windows-latest, windows-11-arm]
-        python-version: ["3.9","3.10", "3.11", "3.12", "3.13", "3.14"]
+        # macos-latest is macOS 26 arm64, so listing macos-26 as well only
+        # duplicated it; macos-15 covers the previous arm64 image instead.
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15, macos-15-intel, macos-26-intel, windows-latest, windows-11-arm]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         exclude:
           - os: windows-11-arm
             python-version: "3.9"
           - os: windows-11-arm
             python-version: "3.10"
+          # Already covered by the quick gate.
+          - os: ubuntu-latest
+            python-version: "3.12"
       fail-fast: false
-    steps:
-    - uses: actions/checkout@v7
-      with:
-        submodules: False
-        fetch-depth: 3
-    - uses: hendrikmuhs/ccache-action@v1.2
-      with:
-        key: ${{ github.job }}-${{ matrix.os }}-${{ matrix.python-version }}
-    - uses: astral-sh/setup-uv@v7
-    - uses: actions/setup-python@v7
-      with:
-        python-version: ${{ matrix.python-version }}
-        allow-prereleases: true
-    - name: Install requirements
-      run: uv pip install -e . --group test ${{ (runner.os != 'macOS' && runner.arch != 'ARM64') && 'mkl' || '' }}
-    - name: Check MKL version
-      if: runner.os != 'macOS' && runner.arch != 'ARM64'
-      run: pip show mkl
-    - name: Cache test database
-      id: cache-db
-      uses: actions/cache@v6
-      with:
-        path: src/MCEq/data/mceq_db_v140reduced_compact.h5
-        key: mceq-test-db-v1-${{ runner.os }}
-
-    - name: Download test database if not cached
-      if: steps.cache-db.outputs.cache-hit != 'true'
-      shell: bash
-      run: |
-        curl -L https://github.com/mceq-project/MCEq/releases/download/ci-assets/mceq_db_v140reduced_compact.h5 -o src/MCEq/data/mceq_db_v140reduced_compact.h5
-    - name: Run tests
-      run: pytest --cov=MCEq --cov-branch --cov-report=xml -n 3 --dist loadgroup
-    - name: Upload coverage reports to Codecov
-      if: matrix.python-version == '3.14'
-      uses: codecov/codecov-action@v7
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        flags: ${{ matrix.os }}
+    uses: ./.github/workflows/_run_tests.yml
+    secrets: inherit
+    with:
+      os: ${{ matrix.os }}
+      python-version: ${{ matrix.python-version }}
+      upload-coverage: ${{ matrix.python-version == '3.14' }}

--- a/changes/175.chore.md
+++ b/changes/175.chore.md
@@ -1,0 +1,8 @@
+CI is now staged so platform breakage fails fast. The release workflow gained a
+`smoke` stage (Python 3.14 on all six platforms) that the 46-job wheel matrix
+depends on, its pull-request trigger widened from "this workflow changed" to
+`CMakeLists.txt`, `pyproject.toml` and `src/**`, and every job carries a
+timeout — a runner that loses contact with the server no longer sits on the 6 h
+default (it cost 2 h in run 31360781445). The test matrix moved into a
+`workflow_call` workflow behind a one-job `quick` gate, and `macos-26` was
+replaced by `macos-15` because `macos-latest` already covers macOS 26 arm64.


### PR DESCRIPTION
The `macos-26-intel / cp314` job that reddened `main` was a runner that lost
contact with the server, not a code or config problem — re-running it is green.
So this is hardening, not a fix.

**Commit 1 — release workflow**

- `timeout-minutes` on every job (20 for wheels). That job ran 7500 s against
  28–115 s for the rest of the matrix before the 6 h default would have expired.
- The PR-only `test_pr` job becomes a `smoke` stage that `wheels` depends on:
  cp314 × 6 platforms, ~2 min each. Platform breakage now costs 6 jobs, not 46.
- Widen its PR trigger from "this workflow changed" to `CMakeLists.txt`,
  `pyproject.toml`, `src/**` — none of those were built on any platform before
  landing on `main`.
- `concurrency` falls back to `run_id`: `head_ref` is empty on push and tag, so
  main pushes and tags cancelled each other.

**Commit 2 — test matrix, droppable**

Moves the per-platform steps into a `workflow_call` workflow and puts a one-job
gate (ubuntu-latest, 3.12) in front of the 46-job matrix. Also replaces
`macos-26` with `macos-15`, since `macos-latest` already *is* macOS 26 arm64.

⚠️ Job names become `test (macos-latest, 3.14) / test`, so required status checks
need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014arqpGfDHtJek6cJXF2gd9
