### PR TITLE
2D: add secant multi-RHS carousel

### DIFF
--- a/changes/+secant-carousel.feat.md
+++ b/changes/+secant-carousel.feat.md
@@ -1,0 +1,1 @@
+Add cap-grouped secant-theta transport to NumPy and CUDA multi-RHS/full-sky carousel solves, preserving per-column paths and initial states without a paraxial downgrade.

--- a/src/MCEq/config.py
+++ b/src/MCEq/config.py
@@ -376,12 +376,12 @@ muon_multiple_scattering = True
 #: Applied inside the ETD2RK kernels (numpy/mkl/cuda): the coupled
 #: same-(species,E) block d_i*S_P is integrated exactly in the
 #: eigenbasis of S_P, unconditionally stable at any stiffness.
-#: Tri-state: "auto" (default) applies the correction to every
-#: single-axis solve() on a 2D database and falls back to the paraxial
-#: transport (with a warning) on the multi-RHS/carousel entry points
-#: and kernels where the coupling is not implemented; True requires it
-#: (unsupported paths raise); False disables it. 1D databases are
-#: never affected.
+#: Tri-state: "auto" (default) applies the correction wherever a secant
+#: kernel is implemented; True requires it; False disables it. Batched
+#: multi-RHS/carousel transport is supported on NumPy and CUDA, grouping
+#: columns by their resolved auto-cap so every RHS receives its own operator.
+#: Active secant modes raise on unsupported batched backends instead of
+#: silently falling back to paraxial transport. 1D databases are unaffected.
 secant_theta_transport = "auto"
 #: cap angle in degrees for the sec(theta) growth (transport breaks down
 #: at 90 deg), or the string "auto". For an axis inclined at zenith

--- a/src/MCEq/core.py
+++ b/src/MCEq/core.py
@@ -126,15 +126,11 @@ class MCEqBatchResult:
         """
         n_selected = sum(x is not None for x in (k, pixel, zenith))
         if n_selected > 1:
-            raise ValueError(
-                "column_index: provide only one of k, pixel, or zenith"
-            )
+            raise ValueError("column_index: provide only one of k, pixel, or zenith")
         if k is not None:
             k = int(k)
             if not -self.K <= k < self.K:
-                raise IndexError(
-                    f"column_index: k={k} out of range for K={self.K}"
-                )
+                raise IndexError(f"column_index: k={k} out of range for K={self.K}")
             return k % self.K
 
         if pixel is not None or zenith is not None:
@@ -156,8 +152,7 @@ class MCEqBatchResult:
             match = np.flatnonzero(np.isclose(self.zenith_grid, zenith))
             if match.size == 0:
                 raise ValueError(
-                    f"column_index: zenith {zenith} not in grid "
-                    f"{self.zenith_grid}"
+                    f"column_index: zenith {zenith} not in grid {self.zenith_grid}"
                 )
             i_zen = int(match[0])
             if azimuth is None:
@@ -225,8 +220,7 @@ class MCEqBatchResult:
         else:
             if self.grid_sol is None or len(self.grid_sol) == 0:
                 raise Exception(
-                    "Solution has not been computed on a grid. "
-                    "Re-run with int_grid."
+                    "Solution has not been computed on a grid. Re-run with int_grid."
                 )
             if grid_idx >= len(self.grid_sol):
                 state = self.grid_sol[-1][:, col]
@@ -259,9 +253,7 @@ class MCEqBatchResult:
           (np.ndarray[n_zen, n_az]): flux map, kinetic-energy units.
         """
         if self.zenith_grid is None:
-            raise ValueError(
-                "skymap() is only available on solve_fullsky results"
-            )
+            raise ValueError("skymap() is only available on solve_fullsky results")
         e_grid = self._mceq.e_grid
         if not e_grid[0] <= kin_energy <= e_grid[-1]:
             raise ValueError(
@@ -296,9 +288,7 @@ class MCEqBatchResult:
     def __repr__(self):
         parts = [f"K={self.sol.shape[1]}"]
         if self.zenith_grid is not None:
-            parts.append(
-                f"sky_grid={self.zenith_grid.size}x{self.n_azimuth}"
-            )
+            parts.append(f"sky_grid={self.zenith_grid.size}x{self.n_azimuth}")
         if self.grid_sol is not None and len(self.grid_sol):
             parts.append(f"n_snapshots={len(self.grid_sol)}")
         return f"MCEqBatchResult({', '.join(parts)})"
@@ -357,9 +347,7 @@ class MCEqRun:
         he_le_transition = kwargs.pop(
             "he_le_transition", le_config.get("he_le_transition", 80.0)
         )
-        he_le_trwidth = kwargs.pop(
-            "he_le_trwidth", le_config.get("he_le_trwidth", 0.3)
-        )
+        he_le_trwidth = kwargs.pop("he_le_trwidth", le_config.get("he_le_trwidth", 0.3))
         self._mceq_db = MCEq.data.HDF5Backend(
             medium=self.medium,
             low_energy_model=low_energy_model,
@@ -1202,8 +1190,7 @@ class MCEqRun:
 
             # response matrix: one column per primary energy
             phi0 = np.stack(
-                [mceq.initial_state({"E": E, "pdg_id": 2212})
-                 for E in E_primaries],
+                [mceq.initial_state({"E": E, "pdg_id": 2212}) for E in E_primaries],
                 axis=1,
             )
             res = mceq.solve_batch(phi0)
@@ -1775,20 +1762,26 @@ class MCEqRun:
             grid_idcs,
         )
 
-    def _dispatch_cuda_multirhs(self, nsteps, dX, rho_inv, grid_idcs, phi0, dtype):
-        """Pick the cupy multirhs kernel and reuse a per-(dtype, K) context
-        cache. The context owns the cuSPARSE CSR copies of the off-diagonals
-        and the (dim, K) state/scratch buffers, so reconstructing them costs
-        a non-trivial number of allocations + CSR builds. Cached in
-        ``self._cuda_etd2_multirhs_cache`` keyed on (dtype, K) and tied
-        to the current ``int_m`` / ``dec_m`` identity.
+    def _cuda_multirhs_context(self, K, dtype):
+        """Return a cached CUDA multi-RHS context for one pipeline width.
+
+        Width-specific contexts own their ``(dim, K)`` work buffers. Contexts
+        tied to the same host matrix identities, device and precision share
+        immutable GPU CSR matrices and diagonals, avoiding one large upload per
+        secant cap-group width.
         """
         import MCEq.solvers
         from MCEq.solvers import _etd_split_cache
 
+        dtype = np.dtype(dtype)
+        if dtype not in (np.float32, np.float64):
+            raise ValueError(f"CUDA multi-RHS dtype must be float32/64, got {dtype}")
+        K = int(K)
+        if K < 1:
+            raise ValueError(f"CUDA multi-RHS K must be >= 1, got {K}")
         fp_precision = 32 if dtype == np.float32 else 64
-        dim, K = phi0.shape
-        cache_key = (fp_precision, K)
+        device_id = int(self._cuda_device)
+        cache_key = (device_id, fp_precision, K)
         cache = getattr(self, "_cuda_etd2_multirhs_cache", None)
         if cache is None:
             cache = {}
@@ -1796,30 +1789,73 @@ class MCEqRun:
 
         entry = cache.get(cache_key)
         if (
-            entry is None
-            or entry["int_m"] is not self.int_m
-            or entry["dec_m"] is not self.dec_m
+            entry is not None
+            and entry["int_m"] is self.int_m
+            and entry["dec_m"] is self.dec_m
+            and entry["device_id"] == device_id
         ):
-            d_int, d_dec, int_off, dec_off = _etd_split_cache(
-                self.int_m, self.dec_m
+            return entry["ctx"]
+
+        d_int, d_dec, int_off, dec_off = _etd_split_cache(self.int_m, self.dec_m)
+        shared_static = None
+        for candidate in cache.values():
+            if (
+                candidate["int_m"] is self.int_m
+                and candidate["dec_m"] is self.dec_m
+                and candidate["device_id"] == device_id
+                and candidate["ctx"].fl_pr.__name__ == f"float{fp_precision}"
+            ):
+                shared_static = candidate["ctx"]
+                break
+        ctx = MCEq.solvers.CudaEtd2MultiRHSContext(
+            int_off,
+            dec_off,
+            d_int,
+            d_dec,
+            K=K,
+            device_id=device_id,
+            fp_precision=fp_precision,
+            shared_static=shared_static,
+        )
+        cache[cache_key] = {
+            "int_m": self.int_m,
+            "dec_m": self.dec_m,
+            "device_id": device_id,
+            "ctx": ctx,
+        }
+        return ctx
+
+    def _dispatch_cuda_multirhs(
+        self,
+        nsteps,
+        dX,
+        rho_inv,
+        grid_idcs,
+        phi0,
+        dtype,
+        sec_ops=None,
+    ):
+        """Pick the cupy multirhs kernel and reuse a per-(device, dtype, K) context
+        cache. The context owns the cuSPARSE CSR copies of the off-diagonals
+        and the (dim, K) state/scratch buffers, so reconstructing them costs
+        a non-trivial number of allocations + CSR builds. Cached in
+        ``self._cuda_etd2_multirhs_cache`` keyed on (device, dtype, K)
+        and tied to the current ``int_m`` / ``dec_m`` identity.
+        """
+        import MCEq.solvers
+
+        _dim, K = phi0.shape
+        ctx = self._cuda_multirhs_context(K, dtype)
+        if sec_ops is not None:
+            return MCEq.solvers.solv_cuda_etd2_secant_multirhs(
+                nsteps,
+                dX,
+                rho_inv,
+                ctx,
+                phi0,
+                grid_idcs,
+                sec_ops,
             )
-            device_id = int(getattr(config, "cuda_device_id", 0))
-            ctx = MCEq.solvers.CudaEtd2MultiRHSContext(
-                int_off,
-                dec_off,
-                d_int,
-                d_dec,
-                K=K,
-                device_id=device_id,
-                fp_precision=fp_precision,
-            )
-            cache[cache_key] = {
-                "int_m": self.int_m,
-                "dec_m": self.dec_m,
-                "ctx": ctx,
-            }
-            entry = cache[cache_key]
-        ctx = entry["ctx"]
         return MCEq.solvers.solv_cuda_etd2_multirhs(
             nsteps,
             dX,
@@ -1883,7 +1919,16 @@ class MCEqRun:
             grid_idcs,
         )
 
-    def _dispatch_shared_path_multirhs(self, nsteps, dX, rho_inv, grid_idcs, phi0, dtype):
+    def _dispatch_shared_path_multirhs(
+        self,
+        nsteps,
+        dX,
+        rho_inv,
+        grid_idcs,
+        phi0,
+        dtype,
+        sec_ops=None,
+    ):
         """Route a shared-path multi-RHS solve to the ``kernel_config``
         backend.
 
@@ -1894,10 +1939,11 @@ class MCEqRun:
         route :meth:`solve_batch` picks automatically whenever all batch
         members resolve to the same path.
 
-        Supports all four backends (``numpy_etd2``, ``accelerate_etd2``,
-        ``cuda_etd2``, ``mkl_etd2``), ``int_grid`` snapshots, fp32 state
-        buffers (except on ``numpy_etd2``) and the EM ρ-stack
-        (``numpy_etd2`` only).
+        Paraxial transport supports all four backends (``numpy_etd2``,
+        ``accelerate_etd2``, ``cuda_etd2``, ``mkl_etd2``), ``int_grid``
+        snapshots, fp32 state buffers (except on ``numpy_etd2``), and the EM
+        ρ-stack (``numpy_etd2`` only). Secant transport is implemented here for
+        NumPy and CUDA fp32/fp64; production validation uses CUDA fp64.
         """
         import MCEq.solvers
 
@@ -1918,6 +1964,11 @@ class MCEqRun:
             int_m_stack = getattr(self, "_int_m_stack", None)
             em_rho_grid = getattr(self, "_em_rho_grid", None)
             if int_m_stack is not None and em_rho_grid is not None:
+                if sec_ops is not None:
+                    raise NotImplementedError(
+                        "solve_batch: secant_theta_transport cannot be combined "
+                        "with the EM rho-stack density interpolation."
+                    )
                 return MCEq.solvers.solv_numpy_etd2_rho_stack_multirhs(
                     nsteps,
                     dX,
@@ -1928,18 +1979,40 @@ class MCEqRun:
                     phi0,
                     grid_idcs,
                 )
-            return MCEq.solvers.solv_numpy_etd2_multirhs(
-                nsteps, dX, rho_inv, self.int_m, self.dec_m, phi0, grid_idcs
+            solver = (
+                MCEq.solvers.solv_numpy_etd2_secant_multirhs
+                if sec_ops is not None
+                else MCEq.solvers.solv_numpy_etd2_multirhs
             )
+            args = (nsteps, dX, rho_inv, self.int_m, self.dec_m, phi0, grid_idcs)
+            if sec_ops is not None:
+                args += (sec_ops,)
+            return solver(*args)
         if kc == "accelerate_etd2":
+            if sec_ops is not None:
+                raise NotImplementedError(
+                    "solve_batch: secant_theta_transport is not implemented "
+                    "for the Accelerate multi-RHS kernel."
+                )
             return self._dispatch_spacc_multirhs(
                 nsteps, dX, rho_inv, grid_idcs, phi0, dtype
             )
         if kc == "cuda_etd2":
             return self._dispatch_cuda_multirhs(
-                nsteps, dX, rho_inv, grid_idcs, phi0, dtype
+                nsteps,
+                dX,
+                rho_inv,
+                grid_idcs,
+                phi0,
+                dtype,
+                sec_ops=sec_ops,
             )
         if kc == "mkl_etd2":
+            if sec_ops is not None:
+                raise NotImplementedError(
+                    "solve_batch: secant_theta_transport is not implemented "
+                    "for the MKL multi-RHS kernel."
+                )
             return self._dispatch_mkl_multirhs(
                 nsteps, dX, rho_inv, grid_idcs, phi0, dtype
             )
@@ -1964,6 +2037,7 @@ class MCEqRun:
         dX_max=None,
         dX_min=None,
         fd_span=None,
+        X_stop_fraction=None,
     ):
         """Solve K independent cascade problems in one batched call.
 
@@ -1998,15 +2072,17 @@ class MCEqRun:
 
             # K single primaries (response matrix) at the current angle
             phi0 = np.stack(
-                [mceq.initial_state({"E": E, "pdg_id": 2212})
-                 for E in E_primaries], axis=1)
+                [mceq.initial_state({"E": E, "pdg_id": 2212}) for E in E_primaries],
+                axis=1,
+            )
             res = mceq.solve_batch(phi0)
 
             # one spectrum through 12 months x 3 zeniths
             conditions = [
-                {"zenith_deg": z,
-                 "density_model": ("MSIS21", ("SouthPole", month))}
-                for month in months for z in (0.0, 30.0, 60.0)]
+                {"zenith_deg": z, "density_model": ("MSIS21", ("SouthPole", month))}
+                for month in months
+                for z in (0.0, 30.0, 60.0)
+            ]
             res = mceq.solve_batch(conditions=conditions)
             res.get_solution("conv_numu", k=5, mag=3)
 
@@ -2040,6 +2116,11 @@ class MCEqRun:
             non-uniform path knobs forwarded to
             :meth:`_calculate_integration_path`; same semantics as
             :meth:`solve`.
+          X_stop_fraction (float | None): stop every path at the exact
+            snapshot depth ``fraction * density_model.max_X``. Must satisfy
+            ``0 < fraction <= 1`` and cannot be combined with ``int_grid``
+            or ``path_workers > 1``. ``None`` preserves the standard
+            full-column endpoint exactly.
 
         Returns:
           :class:`MCEqBatchResult`: final states plus per-column
@@ -2052,7 +2133,24 @@ class MCEqRun:
                 f"solve_batch: dtype must be float32 or float64, got {dtype}"
             )
 
-        self._require_no_secant("solve_batch")
+        secant_on = self._require_batch_secant_supported("solve_batch")
+        if X_stop_fraction is not None:
+            X_stop_fraction = float(X_stop_fraction)
+            if not 0.0 < X_stop_fraction <= 1.0:
+                raise ValueError(
+                    "solve_batch: X_stop_fraction must satisfy "
+                    f"0 < fraction <= 1, got {X_stop_fraction}"
+                )
+            if int_grid is not None:
+                raise ValueError(
+                    "solve_batch: X_stop_fraction cannot be combined with "
+                    "int_grid snapshots."
+                )
+            if int(path_workers or 0) > 1:
+                raise ValueError(
+                    "solve_batch: X_stop_fraction is currently supported "
+                    "only with path_workers <= 1."
+                )
 
         # --- resolve phi0 ------------------------------------------------
         if phi0 is None:
@@ -2075,8 +2173,7 @@ class MCEqRun:
             n_cols = phi0_arr.shape[1]
         else:
             raise ValueError(
-                f"solve_batch: phi0 must be 1-D or 2-D, "
-                f"got shape {phi0_arr.shape}"
+                f"solve_batch: phi0 must be 1-D or 2-D, got shape {phi0_arr.shape}"
             )
 
         if conditions is not None:
@@ -2104,9 +2201,7 @@ class MCEqRun:
         # same amplitude, so tile the rows across the n_k blocks — the
         # exact analogue of the np.tile in solve().
         if self._mceq_db.is_2d:
-            phi0_mat = np.ascontiguousarray(
-                np.tile(phi0_mat, (self._mceq_db.n_k, 1))
-            )
+            phi0_mat = np.ascontiguousarray(np.tile(phi0_mat, (self._mceq_db.n_k, 1)))
 
         # --- build integration paths -------------------------------------
         path_kwargs = dict(
@@ -2115,11 +2210,17 @@ class MCEqRun:
         if conditions is None:
             if int_grid is not None and np.any(np.diff(int_grid) < 0):
                 raise Exception(
-                    "The X values in int_grid are required to be "
-                    "strictly increasing."
+                    "The X values in int_grid are required to be strictly increasing."
                 )
-            self._calculate_integration_path(int_grid, grid_var, **path_kwargs)
-            paths = [self.integration_path] * K
+            endpoint_grid = int_grid
+            if X_stop_fraction is not None:
+                endpoint_grid = [X_stop_fraction * float(self.density_model.max_X)]
+            self._calculate_integration_path(endpoint_grid, grid_var, **path_kwargs)
+            path = self.integration_path
+            if X_stop_fraction is not None:
+                path = self._truncate_path_at_last_snapshot(path, "solve_batch")
+                self.integration_path = path
+            paths = [path] * K
         else:
             if int_grid is not None:
                 raise NotImplementedError(
@@ -2133,11 +2234,17 @@ class MCEqRun:
                     "solve_batch: only grid_var='X' is supported."
                 )
             paths = self._build_condition_paths(
-                conditions, path_workers=path_workers, **path_kwargs
+                conditions,
+                path_workers=path_workers,
+                X_stop_fraction=X_stop_fraction,
+                **path_kwargs,
             )
 
         nsteps_per_col = np.array([p[0] for p in paths], dtype=np.int32)
         shared = all(p is paths[0] for p in paths)
+        secant_caps = (
+            self._secant_caps_for_conditions(conditions, K) if secant_on else None
+        )
 
         start = time()
         if shared:
@@ -2152,8 +2259,22 @@ class MCEqRun:
             # for the fp32 path (exp(h·D) saturates fp32 fast at high
             # zenith).
             phi0_typed = phi0_mat.astype(dtype, copy=True)
+            sec_ops = None
+            if secant_on:
+                if not np.all(secant_caps == secant_caps[0]):
+                    raise RuntimeError(
+                        "solve_batch: columns sharing one integration path "
+                        "resolved to different secant operators"
+                    )
+                sec_ops = self._build_secant_ops(secant_caps[0])
             sol, grid_sol = self._dispatch_shared_path_multirhs(
-                nsteps, dX, rho_inv, grid_idcs, phi0_typed, dtype
+                nsteps,
+                dX,
+                rho_inv,
+                grid_idcs,
+                phi0_typed,
+                dtype,
+                sec_ops=sec_ops,
             )
             legacy = (sol, grid_sol)
         else:
@@ -2166,23 +2287,66 @@ class MCEqRun:
                 )
             from MCEq.solvers import compile_carousel_schedule, schedule_lpt
 
-            if carousel_K is None:
-                carousel_K = min(K, 128)
-            K_pipe = max(1, min(int(carousel_K), K))
-            slots, T = schedule_lpt(nsteps_per_col, K_pipe)
-            dX_c, ri_c, phi_init, sched = compile_carousel_schedule(
-                paths, slots, T, phi0_mat.shape[0], phi0_mat
-            )
-            sum_ns = int(nsteps_per_col.sum())
-            waste = 1.0 - sum_ns / float(T * K_pipe) if (T * K_pipe) else 0.0
-            info(
-                2,
-                f"solve_batch: carousel route K={K} K_pipe={K_pipe} T={T} "
-                f"sum_nsteps={sum_ns} waste={waste*100:.2f}%",
-            )
-            sol = self._dispatch_carousel(
-                dX_c, ri_c, phi_init, sched, phi0_mat, dtype=dtype
-            )
+            requested_K = min(K, 128) if carousel_K is None else int(carousel_K)
+            if secant_on:
+                # Auto caps depend on zenith. Keep every carousel homogeneous
+                # in S=I+T, reuse one eigensystem per cap, and scatter each
+                # local pixel order back into the legacy global column order.
+                groups = {}
+                for pixel_id, cap in enumerate(secant_caps):
+                    groups.setdefault(float(cap), []).append(pixel_id)
+
+                sol = np.empty((phi0_mat.shape[0], K), dtype=dtype)
+                for cap, pixel_ids_list in groups.items():
+                    pixel_ids = np.asarray(pixel_ids_list, dtype=np.int64)
+                    group_paths = [paths[int(pid)] for pid in pixel_ids]
+                    group_phi0 = np.ascontiguousarray(phi0_mat[:, pixel_ids])
+                    group_nsteps = nsteps_per_col[pixel_ids]
+                    group_K = len(pixel_ids)
+                    K_pipe = max(1, min(requested_K, group_K))
+                    slots, T = schedule_lpt(group_nsteps, K_pipe)
+                    dX_c, ri_c, phi_init, sched = compile_carousel_schedule(
+                        group_paths,
+                        slots,
+                        T,
+                        group_phi0.shape[0],
+                        group_phi0,
+                    )
+                    sum_ns = int(group_nsteps.sum())
+                    waste = 1.0 - sum_ns / float(T * K_pipe) if (T * K_pipe) else 0.0
+                    info(
+                        2,
+                        f"solve_batch: secant carousel cap={cap:g} K={group_K} "
+                        f"K_pipe={K_pipe} T={T} sum_nsteps={sum_ns} "
+                        f"waste={waste * 100:.2f}%",
+                    )
+                    sec_ops = self._build_secant_ops(cap)
+                    group_sol = self._dispatch_carousel(
+                        dX_c,
+                        ri_c,
+                        phi_init,
+                        sched,
+                        group_phi0,
+                        dtype=dtype,
+                        sec_ops=sec_ops,
+                    )
+                    sol[:, pixel_ids] = group_sol
+            else:
+                K_pipe = max(1, min(requested_K, K))
+                slots, T = schedule_lpt(nsteps_per_col, K_pipe)
+                dX_c, ri_c, phi_init, sched = compile_carousel_schedule(
+                    paths, slots, T, phi0_mat.shape[0], phi0_mat
+                )
+                sum_ns = int(nsteps_per_col.sum())
+                waste = 1.0 - sum_ns / float(T * K_pipe) if (T * K_pipe) else 0.0
+                info(
+                    2,
+                    f"solve_batch: carousel route K={K} K_pipe={K_pipe} T={T} "
+                    f"sum_nsteps={sum_ns} waste={waste * 100:.2f}%",
+                )
+                sol = self._dispatch_carousel(
+                    dX_c, ri_c, phi_init, sched, phi0_mat, dtype=dtype
+                )
             grid_sol = None
             legacy = (sol, nsteps_per_col)
 
@@ -2231,8 +2395,8 @@ class MCEqRun:
           (np.ndarray[dim_states, K], np.ndarray[len(int_grid), dim_states, K]):
           final state matrix and stacked snapshots.
         """
-        self._require_no_secant("solve_multirhs")
         phi0_matrix = np.asarray(phi0_matrix)
+        self._require_batch_secant_supported("solve_multirhs")
         if phi0_matrix.ndim != 2:
             raise ValueError(
                 f"solve_multirhs: phi0_matrix must be 2-D (dim_states, K), "
@@ -2252,6 +2416,28 @@ class MCEqRun:
         )
         return res.sol, res.grid_sol
 
+    @staticmethod
+    def _truncate_path_at_last_snapshot(path, caller):
+        """Return a path ending immediately after its final grid snapshot."""
+        _nsteps, dX, rho_inv, grid_idcs = path
+        if len(grid_idcs) != 1:
+            raise RuntimeError(
+                f"{caller}: expected exactly one endpoint snapshot, got "
+                f"{len(grid_idcs)}"
+            )
+        stop = int(grid_idcs[-1]) + 1
+        if stop < 1 or stop > len(dX) or stop > len(rho_inv):
+            raise RuntimeError(
+                f"{caller}: invalid endpoint snapshot step {grid_idcs[-1]} "
+                f"for path lengths dX={len(dX)}, rho_inv={len(rho_inv)}"
+            )
+        return (
+            stop,
+            np.asarray(dX)[:stop].copy(),
+            np.asarray(rho_inv)[:stop].copy(),
+            [],
+        )
+
     def _build_condition_paths(
         self,
         conditions,
@@ -2262,6 +2448,7 @@ class MCEqRun:
         dX_min=None,
         fd_span=None,
         path_workers=0,
+        X_stop_fraction=None,
     ):
         """Build one ETD2 integration path per batch condition.
 
@@ -2286,6 +2473,10 @@ class MCEqRun:
             under fork CoW; the pure-Python MSIS21 tree is fork-safe and
             is the production user of this pool, see
             results/allsky-orca-msis21.md).
+          X_stop_fraction (float | None): when set, stop each path at the
+            exact snapshot depth ``fraction * density_model.max_X``. The
+            range is ``0 < fraction <= 1``. Parallel path building is not
+            supported for this endpoint mode.
 
         Returns:
           list: ``(nsteps, dX, rho_inv, grid_idcs)`` tuples, one per
@@ -2313,6 +2504,18 @@ class MCEqRun:
 
         has_dm_override = any(c.get("density_model") is not None for c in norm)
         n_workers = int(path_workers) if path_workers else 0
+        if X_stop_fraction is not None:
+            X_stop_fraction = float(X_stop_fraction)
+            if not 0.0 < X_stop_fraction <= 1.0:
+                raise ValueError(
+                    "_build_condition_paths: X_stop_fraction must satisfy "
+                    f"0 < fraction <= 1, got {X_stop_fraction}"
+                )
+            if n_workers > 1:
+                raise ValueError(
+                    "_build_condition_paths: X_stop_fraction is currently "
+                    "supported only with path_workers <= 1."
+                )
         if n_workers > 1:
             if has_dm_override:
                 raise ValueError(
@@ -2427,8 +2630,18 @@ class MCEqRun:
                         self.set_zenith_azimuth(zen)
                     else:
                         self.set_zenith_azimuth(zen, az_eff)
-                    self._calculate_integration_path(None, "X", **kwargs)
-                    unique_paths[pkey] = self.integration_path
+                    endpoint_grid = None
+                    if X_stop_fraction is not None:
+                        endpoint_grid = [
+                            X_stop_fraction * float(self.density_model.max_X)
+                        ]
+                    self._calculate_integration_path(endpoint_grid, "X", **kwargs)
+                    path = self.integration_path
+                    if X_stop_fraction is not None:
+                        path = self._truncate_path_at_last_snapshot(
+                            path, "_build_condition_paths"
+                        )
+                    unique_paths[pkey] = path
 
             return [unique_paths[k] for k in cond_keys]
         finally:
@@ -2449,6 +2662,7 @@ class MCEqRun:
         dX_min=None,
         fd_span=None,
         path_workers=0,
+        X_stop_fraction=None,
     ):
         """Build per-pixel ETD2 integration paths for a (zenith × azimuth) grid.
 
@@ -2492,6 +2706,7 @@ class MCEqRun:
             dX_min=dX_min,
             fd_span=fd_span,
             path_workers=path_workers,
+            X_stop_fraction=X_stop_fraction,
         )
         return paths, pixel_index, K
 
@@ -2503,16 +2718,22 @@ class MCEqRun:
         schedule,
         phi0_per_pixel,
         dtype=np.float64,
+        sec_ops=None,
     ):
         """Dispatch one carousel solve to the ``kernel_config`` backend
-        (all four backends are wired: numpy/cuda/mkl/accelerate ETD2).
+        (all four paraxial backends, plus numpy/cuda secant ETD2).
         Returns ``(dim, K_total)`` pixel-order final states.
         """
         import MCEq.solvers
 
         kc = config.kernel_config.lower()
         if kc == "numpy_etd2":
-            sol = MCEq.solvers.solv_numpy_etd2_carousel(
+            solver = (
+                MCEq.solvers.solv_numpy_etd2_secant_carousel
+                if sec_ops is not None
+                else MCEq.solvers.solv_numpy_etd2_carousel
+            )
+            args = (
                 self.int_m,
                 self.dec_m,
                 dX_c,
@@ -2521,52 +2742,48 @@ class MCEqRun:
                 schedule,
                 phi0_per_pixel,
             )
+            if sec_ops is not None:
+                args += (sec_ops,)
+            sol = solver(*args)
             return np.asarray(sol, dtype=np.dtype(dtype))
         if kc == "cuda_etd2":
-            # Reuse the multi-RHS cupy context cache (keyed on (dtype, K))
+            # Reuse the multi-RHS cupy context cache (keyed on device/dtype/K)
             # — the carousel uses ctx.K = K_pipe (pipeline width), not
             # K_total. Different K_pipe values get separate ctx slots.
-            from MCEq.solvers import _etd_split_cache
-
             K_pipe = schedule.K
             dtype = np.dtype(dtype)
             if dtype not in (np.float32, np.float64):
                 raise ValueError(
                     f"_dispatch_carousel: cuda dtype must be float32/64, got {dtype}"
                 )
-            fp_precision = 32 if dtype == np.float32 else 64
-            cache_key = (fp_precision, K_pipe)
-            cache = getattr(self, "_cuda_etd2_multirhs_cache", None)
-            if cache is None:
-                cache = {}
-                self._cuda_etd2_multirhs_cache = cache
-            entry = cache.get(cache_key)
-            if (
-                entry is None
-                or entry["int_m"] is not self.int_m
-                or entry["dec_m"] is not self.dec_m
-            ):
-                d_int, d_dec, int_off, dec_off = _etd_split_cache(
-                    self.int_m, self.dec_m
-                )
-                device_id = int(getattr(config, "cuda_device_id", 0))
-                ctx = MCEq.solvers.CudaEtd2MultiRHSContext(
-                    int_off, dec_off, d_int, d_dec,
-                    K=K_pipe, device_id=device_id,
-                    fp_precision=fp_precision,
-                )
-                cache[cache_key] = {"int_m": self.int_m, "dec_m": self.dec_m, "ctx": ctx}
-                entry = cache[cache_key]
-            ctx = entry["ctx"]
+            ctx = self._cuda_multirhs_context(K_pipe, dtype)
             phi_init_typed = np.asarray(phi_initial, dtype=dtype)
             phi0_typed = np.asarray(phi0_per_pixel, dtype=dtype)
             dX_typed = np.asarray(dX_c, dtype=dtype)
             ri_typed = np.asarray(rho_inv_c, dtype=dtype)
-            sol = MCEq.solvers.solv_cuda_etd2_carousel(
-                ctx, dX_typed, ri_typed, phi_init_typed, schedule, phi0_typed
+            solver = (
+                MCEq.solvers.solv_cuda_etd2_secant_carousel
+                if sec_ops is not None
+                else MCEq.solvers.solv_cuda_etd2_carousel
             )
+            args = (
+                ctx,
+                dX_typed,
+                ri_typed,
+                phi_init_typed,
+                schedule,
+                phi0_typed,
+            )
+            if sec_ops is not None:
+                args += (sec_ops,)
+            sol = solver(*args)
             return sol
         if kc == "mkl_etd2":
+            if sec_ops is not None:
+                raise NotImplementedError(
+                    "_dispatch_carousel: secant_theta_transport is not "
+                    "implemented for the MKL carousel."
+                )
             from MCEq.solvers import _etd_split_cache
 
             cache_attr = "_mkl_etd2_cache_multirhs"
@@ -2576,7 +2793,9 @@ class MCEqRun:
                 or cached["int_m"] is not self.int_m
                 or cached["dec_m"] is not self.dec_m
             ):
-                d_int, d_dec, int_off, dec_off = _etd_split_cache(self.int_m, self.dec_m)
+                d_int, d_dec, int_off, dec_off = _etd_split_cache(
+                    self.int_m, self.dec_m
+                )
                 new_cached = {
                     "int_m": self.int_m,
                     "dec_m": self.dec_m,
@@ -2598,11 +2817,23 @@ class MCEqRun:
                             old.close()
             c = getattr(self, cache_attr)
             sol = MCEq.solvers.solv_mkl_etd2_carousel(
-                c["mkl_int_off"], c["mkl_dec_off"], c["d_int"], c["d_dec"],
-                dX_c, rho_inv_c, phi_initial, schedule, phi0_per_pixel,
+                c["mkl_int_off"],
+                c["mkl_dec_off"],
+                c["d_int"],
+                c["d_dec"],
+                dX_c,
+                rho_inv_c,
+                phi_initial,
+                schedule,
+                phi0_per_pixel,
             )
             return np.asarray(sol, dtype=np.dtype(dtype))
         if kc in ("accelerate_etd2", "spacc_etd2"):
+            if sec_ops is not None:
+                raise NotImplementedError(
+                    "_dispatch_carousel: secant_theta_transport is not "
+                    "implemented for the Accelerate carousel."
+                )
             import MCEq.spacc as spacc
             from MCEq.solvers import _etd_split_cache
 
@@ -2613,7 +2844,9 @@ class MCEqRun:
                 or cached["int_m"] is not self.int_m
                 or cached["dec_m"] is not self.dec_m
             ):
-                d_int, d_dec, int_off, dec_off = _etd_split_cache(self.int_m, self.dec_m)
+                d_int, d_dec, int_off, dec_off = _etd_split_cache(
+                    self.int_m, self.dec_m
+                )
                 new_cached = {
                     "int_m": self.int_m,
                     "dec_m": self.dec_m,
@@ -2629,8 +2862,15 @@ class MCEqRun:
                 setattr(self, cache_attr, new_cached)
             c = getattr(self, cache_attr)
             sol = MCEq.solvers.solv_spacc_etd2_carousel(
-                c["spacc_int_off"], c["spacc_dec_off"], c["d_int"], c["d_dec"],
-                dX_c, rho_inv_c, phi_initial, schedule, phi0_per_pixel,
+                c["spacc_int_off"],
+                c["spacc_dec_off"],
+                c["d_int"],
+                c["d_dec"],
+                dX_c,
+                rho_inv_c,
+                phi_initial,
+                schedule,
+                phi0_per_pixel,
             )
             return np.asarray(sol, dtype=np.dtype(dtype))
         raise NotImplementedError(
@@ -2676,6 +2916,7 @@ class MCEqRun:
         dX_max=None,
         dX_min=None,
         fd_span=None,
+        X_stop_fraction=None,
         return_pixel_index=False,
         path_workers=0,
         geomagnetic_cutoff=None,
@@ -2687,8 +2928,8 @@ class MCEqRun:
         ``dX``/``rho_inv``/``nsteps``) and runs a Stage-5 LPT static
         carousel: pixels are scheduled into ``K_pipe`` pipeline slots so
         the total kernel work is ``Σ nsteps × ms/RHS`` rather than
-        ``max(nsteps) × K``. Wired for all four backends
-        (``numpy_etd2``, ``cuda_etd2``, ``mkl_etd2``, ``accelerate_etd2``).
+        ``max(nsteps) × K``. Paraxial transport is wired for all four backends;
+        secant transport is wired for NumPy and CUDA.
 
         Args:
             zenith_grid: 1-D zenith angles in degrees.
@@ -2704,6 +2945,10 @@ class MCEqRun:
                 spot across the full-sky benchmarks for K ≤ 2664.
             X_start, eps, dX_max, dX_min, fd_span: per-pixel path-builder
                 knobs.
+            X_stop_fraction: optional endpoint fraction in ``(0, 1]``.
+                Each column stops at the exact integration snapshot
+                ``fraction * density_model.max_X``. ``None`` retains the
+                standard full-column endpoint.
             return_pixel_index: also return the ``(K, 2)`` mapping
                 ``(i_zen, i_az)`` for reshaping back to grid.
             path_workers: fork-pool size for parallel path build. Must
@@ -2724,7 +2969,7 @@ class MCEqRun:
             ``(sol, nsteps_per_col[, pixel_index])`` tuple.
         """
         info(2, f"solve_fullsky: kernel={config.kernel_config}")
-        self._require_no_secant("solve_fullsky")
+        self._require_batch_secant_supported("solve_fullsky")
         start = time()
 
         # Resolve geomagnetic-cutoff toggle. Per-call argument has
@@ -2797,11 +3042,11 @@ class MCEqRun:
             )
         if cutoff_flag and not phi0_is_2d:
             from MCEq.geometry.gtracr_cutoff import (
-                build_phi0_with_cutoff, get_cutoff_map,
+                build_phi0_with_cutoff,
+                get_cutoff_map,
             )
-            az_centres = (
-                azimuth_grid if azimuth_grid is not None else np.array([0.0])
-            )
+
+            az_centres = azimuth_grid if azimuth_grid is not None else np.array([0.0])
             primary = getattr(self, "pmodel", None)
             if primary is None:
                 info(
@@ -2812,7 +3057,10 @@ class MCEqRun:
             else:
                 ck = dict(cutoff_kwargs or {})
                 rc_grid = get_cutoff_map(
-                    self.density_model, zenith_grid, az_centres, **ck,
+                    self.density_model,
+                    zenith_grid,
+                    az_centres,
+                    **ck,
                 )
                 # Pixel order: (i_zen, i_az) flattened with az inner.
                 rc_flat = rc_grid.flatten(order="C")
@@ -2854,6 +3102,7 @@ class MCEqRun:
             dX_max=dX_max,
             dX_min=dX_min,
             fd_span=fd_span,
+            X_stop_fraction=X_stop_fraction,
         )
 
         # Decorate the batch result with the sky-grid metadata and the
@@ -2869,7 +3118,7 @@ class MCEqRun:
         info(2, f"solve_fullsky: total wall {time() - start:.2f}s")
         return res
 
-    def _secant_theta_cap_deg(self):
+    def _secant_theta_cap_deg(self, theta_deg=None):
         """Resolve ``config.secant_theta_cap_deg``, including "auto".
 
         "auto" follows the cap-sweep geometry: for an axis at zenith
@@ -2888,24 +3137,49 @@ class MCEqRun:
         under-corrected relative to the horizon-aware ideal, but it
         lies entirely beyond the 90 - theta_z acceptance horizon where
         the flat-atmosphere law is invalid regardless. Falls back to 75
-        when no zenith has been set yet.
+        when no zenith has been set yet. ``theta_deg`` lets batched callers
+        resolve the operator before/after the mutable atmosphere geometry is
+        restored; ``None`` uses the active density model as before.
         """
         cap = config.secant_theta_cap_deg
         if not (isinstance(cap, str) and cap.lower() == "auto"):
             return float(cap)
-        theta_z = getattr(self.density_model, "theta_deg", None)
+        theta_z = theta_deg
+        if theta_z is None:
+            theta_z = getattr(self.density_model, "theta_deg", None)
         if theta_z is None:
             return 75.0
         cap = 5.0 * round((90.0 - float(theta_z) + 5.0) / 5.0)
         return float(np.clip(cap, 50.0, 75.0))
 
+    def _secant_caps_for_conditions(self, conditions, K):
+        """Resolve one sec(theta) cap per batch member.
+
+        Condition-path construction temporarily mutates the active density
+        model and restores it before propagation. Resolve caps from the
+        explicit condition zeniths instead of consulting that restored state.
+        Missing zeniths follow :meth:`_build_condition_paths` and inherit the
+        density model's current zenith.
+        """
+        saved_zenith = getattr(self.density_model, "theta_deg", None)
+        if conditions is None:
+            cap = self._secant_theta_cap_deg(saved_zenith)
+            return np.full(K, cap, dtype=np.float64)
+
+        caps = np.empty(K, dtype=np.float64)
+        for k, condition in enumerate(conditions):
+            condition = {} if condition is None else condition
+            zenith = condition.get("zenith_deg", saved_zenith)
+            caps[k] = self._secant_theta_cap_deg(zenith)
+        return caps
+
     def _secant_mode(self):
         """Resolve ``config.secant_theta_transport`` against the loaded DB.
 
         Returns one of ``"off"`` (1D database, or the flag is False),
-        ``"auto"`` (the default — apply where implemented, downgrade to
-        paraxial with a warning elsewhere) and ``"require"`` (flag is
-        True — unsupported paths refuse instead of downgrading).
+        ``"auto"`` (the default — apply where implemented) and ``"require"``
+        (flag is True — unsupported paths refuse). Batched entry points never
+        silently discard either active mode.
         """
         flag = getattr(config, "secant_theta_transport", False)
         if not self._mceq_db.is_2d:
@@ -2914,45 +3188,80 @@ class MCEqRun:
             return "auto"
         return "require" if flag else "off"
 
-    def _require_no_secant(self, caller):
-        """Refuse multi-RHS entry points while the secant coupling is on.
+    def _require_batch_secant_supported(self, caller):
+        """Return whether batched sec(theta) transport is active.
 
-        The multi-RHS / carousel kernels do not apply the sec(theta)
-        mode coupling; silently dropping a requested physics correction
-        is worse than refusing. Batching across zeniths would also need
-        per-zenith operators (grouped columns) — see the 2d-on-v2 secant
-        commits. Under the default ``"auto"`` the correction was not
-        explicitly requested, so these entry points warn and proceed
-        with the paraxial transport instead.
+        NumPy is the correctness reference and CUDA is the production
+        carousel backend. Other batched kernels and the EM rho-stack must
+        refuse both ``"auto"`` and strict ``True`` rather than silently run
+        the paraxial system.
         """
         mode = self._secant_mode()
-        if mode == "require":
+        if mode == "off":
+            return False
+
+        kernel = config.kernel_config.lower()
+        if kernel not in ("numpy_etd2", "cuda_etd2"):
             raise NotImplementedError(
-                f"{caller}: secant_theta_transport is not applied by the "
-                "multi-RHS/carousel kernels (single-axis solve() only). "
-                "Set config.secant_theta_transport = False or use solve()."
-            )
-        if mode == "auto":
-            info(
-                1,
-                f"{caller}: sec(theta) transport correction is not "
-                "implemented for the multi-RHS/carousel kernels — "
-                "proceeding with the paraxial 2D transport. Use "
-                "solve() for corrected single-axis results.",
+                f"{caller}: batched secant_theta_transport is implemented "
+                "for kernel_config in ('numpy_etd2', 'cuda_etd2'); got "
+                f"{config.kernel_config!r}. No paraxial downgrade is applied."
             )
 
-    def _build_secant_ops(self):
+        if (
+            getattr(self, "_int_m_stack", None) is not None
+            or getattr(self, "_em_rho_grid", None) is not None
+        ):
+            raise NotImplementedError(
+                f"{caller}: batched secant_theta_transport cannot be combined "
+                "with the EM rho-stack density interpolation. Disable the "
+                "rho-stack or secant transport; no paraxial downgrade is applied."
+            )
+        return True
+
+    def _build_secant_ops(self, theta_cap_deg=None):
         """Build the constant sec(theta) kernel operator set for the
-        current geometry (see :mod:`MCEq.secant`)."""
+        requested geometry and cache its fitted/eigendecomposed data.
+
+        The underlying coupling fit has its own memory/disk cache, but its
+        eigensystem and energy gate otherwise used to be rebuilt on every
+        call. The complete key covers every input that changes the returned
+        operator dictionary.
+        """
         from MCEq.secant import build_secant_kernel_ops
 
-        return build_secant_kernel_ops(
-            self._mceq_db.k_grid,
-            self._energy_grid.c,
-            self.dim_states // self.dim,
-            config,
-            theta_cap_deg=self._secant_theta_cap_deg(),
+        cap = (
+            self._secant_theta_cap_deg()
+            if theta_cap_deg is None
+            else float(theta_cap_deg)
         )
+        k_grid = np.asarray(self._mceq_db.k_grid, dtype=np.float64)
+        e_centers = np.asarray(self._energy_grid.c, dtype=np.float64)
+        n_species = self.dim_states // self.dim
+        e_gate = getattr(config, "secant_theta_e_gate", None)
+        cache_key = (
+            tuple(k_grid),
+            tuple(e_centers),
+            int(n_species),
+            float(cap),
+            float(config.secant_theta_row_kmax),
+            float(config.secant_theta_lam_rel),
+            float(config.secant_theta_w_flat),
+            None if e_gate is None else float(e_gate),
+        )
+        cache = getattr(self, "_secant_kernel_ops_cache", None)
+        if cache is None:
+            cache = {}
+            self._secant_kernel_ops_cache = cache
+        if cache_key not in cache:
+            cache[cache_key] = build_secant_kernel_ops(
+                k_grid,
+                e_centers,
+                n_species,
+                config,
+                theta_cap_deg=cap,
+            )
+        return cache[cache_key]
 
     def _build_kernel_dispatch(self, nsteps, dX, rho_inv, phi0, grid_idcs):
         """Resolve ``config.kernel_config`` to ``(kernel, args)``.
@@ -3260,11 +3569,13 @@ class MCEqRun:
                 delattr(self, cache_attr)
             except AttributeError:
                 pass
-        # CUDA context: drop the dict; cupy's GC reclaims GPU memory.
-        try:
-            delattr(self, "_cuda_etd2_cache")
-        except AttributeError:
-            pass
+        # CUDA contexts: drop both single- and multi-RHS dictionaries;
+        # cupy's GC/allocator reclaims their device buffers.
+        for cache_attr in ("_cuda_etd2_cache", "_cuda_etd2_multirhs_cache"):
+            try:
+                delattr(self, cache_attr)
+            except AttributeError:
+                pass
 
     def __del__(self):
         # Best-effort cleanup; never raise from __del__.

--- a/src/MCEq/solvers.py
+++ b/src/MCEq/solvers.py
@@ -605,15 +605,16 @@ def _secant_phi_factors(ZB):
     """Elementwise phi1/phi2 with Taylor patches for a 2-D block argument."""
     safe = np.where(ZB == 0.0, 1.0, ZB)
     e1 = np.expm1(ZB)
-    phi1 = np.where(np.abs(ZB) > _PHI1_SMALL, e1 / safe,
-                    1.0 + ZB * (0.5 + ZB * _INV_6))
-    phi2 = np.where(np.abs(ZB) > _PHI2_SMALL, (e1 - ZB) / (safe * safe),
-                    0.5 + ZB * (_INV_6 + ZB * _INV_24))
+    phi1 = np.where(np.abs(ZB) > _PHI1_SMALL, e1 / safe, 1.0 + ZB * (0.5 + ZB * _INV_6))
+    phi2 = np.where(
+        np.abs(ZB) > _PHI2_SMALL,
+        (e1 - ZB) / (safe * safe),
+        0.5 + ZB * (_INV_6 + ZB * _INV_24),
+    )
     return np.exp(ZB), phi1, phi2
 
 
-def solv_numpy_etd2_secant(nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs,
-                           sec_ops):
+def solv_numpy_etd2_secant(nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs, sec_ops):
     """ETD2RK with the sec(theta) path-elongation mode coupling.
 
     Integrates ``dPhi/dX = (A + rho_inv B)(I + T_gated) Phi`` where
@@ -656,19 +657,19 @@ def solv_numpy_etd2_secant(nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs,
 
     dim = phi.shape[0]
     P = sec_ops["P"]
-    T_P = sec_ops["T_P"]          # (n_P, n_k)
-    T_PP = sec_ops["T_PP"]        # (n_P, n_P)
+    T_P = sec_ops["T_P"]  # (n_P, n_k)
+    T_PP = sec_ops["T_PP"]  # (n_P, n_P)
     V = sec_ops["V"]
     Vi = sec_ops["Vi"]
-    lam = sec_ops["lam"]          # (n_P,)
-    g_idx = sec_ops["gate_idx"]   # (n_g,)
+    lam = sec_ops["lam"]  # (n_P,)
+    g_idx = sec_ops["gate_idx"]  # (n_g,)
     n_k = sec_ops["n_k"]
     N = dim // n_k
     assert n_k * N == dim, "state dim not divisible by n_k"
     n_P = len(P)
     n_g = len(g_idx)
     # flat state indices of the (coupled mode, gated column) plane
-    flatPG = (P[:, None] * N + g_idx[None, :])  # (n_P, n_g)
+    flatPG = P[:, None] * N + g_idx[None, :]  # (n_P, n_g)
 
     phc = np.zeros(n_padded, dtype=np.float64)
     phc[:dim] = phi
@@ -692,8 +693,8 @@ def solv_numpy_etd2_secant(nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs,
         """Fbuf <- off-diagonal + coupling remainder of the operator at
         xbuf; returns the gathered x_PG for reuse."""
         x2 = xbuf[:dim].reshape(n_k, N)
-        XG = x2[:, g_idx]                     # (n_k, n_g)
-        YG = T_P @ XG                         # coupling u on (P, g)
+        XG = x2[:, g_idx]  # (n_k, n_g)
+        YG = T_P @ XG  # coupling u on (P, g)
         np.copyto(w, xbuf)
         w[:dim].reshape(n_k, N)[np.ix_(P, g_idx)] += YG
         np.copyto(Fbuf, int_off.dot(w))
@@ -722,8 +723,8 @@ def solv_numpy_etd2_secant(nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs,
 
             _etd_compute_diag_factors(h, ri, d_int, d_dec, bufs)
             D2 = D.reshape(n_k, N)
-            Df_PG = D2[np.ix_(P, g_idx)]      # full diag on coupled plane
-            D0_G = D2[0, g_idx]               # k-shared part (kappa = 0)
+            Df_PG = D2[np.ix_(P, g_idx)]  # full diag on coupled plane
+            D0_G = D2[0, g_idx]  # k-shared part (kappa = 0)
 
             # block factors for the exact slot: f(h * D0_i * lam_j)
             ZB = lam[:, None] * (h * D0_G)[None, :]
@@ -761,6 +762,148 @@ def solv_numpy_etd2_secant(nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs,
     )
 
     return phc_v.copy(), np.array(grid_sol)
+
+
+def _secant_left_matmul(matrix, plane):
+    """Apply a mode-space matrix to the first axis of a >=2-D plane.
+
+    The secant multi-RHS kernels carry a logical ``(mode, state, rhs)``
+    tensor.  Flattening the trailing axes turns each mode transform into
+    one dense GEMM instead of one launch/call per RHS.  The helper is
+    deliberately NumPy/CuPy agnostic; both array libraries implement the
+    operations used here.
+    """
+    trailing = plane.shape[1:]
+    return (matrix @ plane.reshape(plane.shape[0], -1)).reshape(
+        (matrix.shape[0],) + trailing
+    )
+
+
+def solv_numpy_etd2_secant_multirhs(
+    nsteps, dX, rho_inv, int_m, dec_m, phi, grid_idcs, sec_ops
+):
+    """Shared-path multi-RHS lift of :func:`solv_numpy_etd2_secant`.
+
+    All RHS columns share the atmosphere path and one resolved secant
+    operator.  Sparse applications are SpMMs over ``(dim, K)`` while the
+    exact coupled diagonal slot is evaluated by flattening the logical
+    ``(n_P, n_gated, K)`` plane into one dense GEMM per transform.
+    """
+    if phi.ndim != 2:
+        raise ValueError(
+            "solv_numpy_etd2_secant_multirhs: phi must be 2-D (dim, K), "
+            f"got shape {phi.shape}"
+        )
+    dim, K = phi.shape
+    if K < 1:
+        raise ValueError(f"K must be >= 1, got {K}")
+
+    d_int, d_dec, int_off, dec_off = _etd_split_cache(int_m, dec_m)
+    if not sp.isspmatrix_csr(int_off):
+        int_off = int_off.tocsr()
+    if not sp.isspmatrix_csr(dec_off):
+        dec_off = dec_off.tocsr()
+
+    P = np.asarray(sec_ops["P"], dtype=np.intp)
+    T_P = np.asarray(sec_ops["T_P"], dtype=np.float64)
+    T_PP = np.asarray(sec_ops["T_PP"], dtype=np.float64)
+    V = np.asarray(sec_ops["V"], dtype=np.float64)
+    Vi = np.asarray(sec_ops["Vi"], dtype=np.float64)
+    lam = np.asarray(sec_ops["lam"], dtype=np.float64)
+    g_idx = np.asarray(sec_ops["gate_idx"], dtype=np.intp)
+    n_k = int(sec_ops["n_k"])
+    N = dim // n_k
+    if n_k * N != dim:
+        raise ValueError("state dim not divisible by secant n_k")
+
+    phc = np.array(phi, dtype=np.float64, copy=True)
+    F_phi = np.empty((dim, K), dtype=np.float64)
+    F_a = np.empty((dim, K), dtype=np.float64)
+    a = np.empty((dim, K), dtype=np.float64)
+    w = np.empty((dim, K), dtype=np.float64)
+    scratch_NK = np.empty((dim, K), dtype=np.float64)
+    bufs = _etd_step_buffers(dim)
+    eD = bufs["eD"]
+    phi1 = bufs["phi1"]
+    phi2 = bufs["phi2"]
+    D = bufs["D"]
+
+    def eval_F(xbuf, Fbuf, ri, Df_PG, D0_G):
+        X3 = xbuf.reshape(n_k, N, K)
+        XG = X3[:, g_idx, :]
+        YG = _secant_left_matmul(T_P, XG)
+        np.copyto(w, xbuf)
+        W3 = w.reshape(n_k, N, K)
+        W3[P[:, None], g_idx[None, :], :] += YG
+        np.copyto(Fbuf, int_off.dot(w))
+        ri_dec = dec_off.dot(w)
+        ri_dec *= ri
+        np.add(Fbuf, ri_dec, out=Fbuf)
+        x_PG = XG[P, :, :]
+        SPxP = x_PG + _secant_left_matmul(T_PP, x_PG)
+        w_PG = x_PG + YG
+        delta = Df_PG[:, :, None] * w_PG - D0_G[None, :, None] * SPxP
+        F3 = Fbuf.reshape(n_k, N, K)
+        F3[P[:, None], g_idx[None, :], :] += delta
+        return x_PG
+
+    grid_sol = []
+    grid_step = 0
+
+    from time import time
+
+    start = time()
+    with np.errstate(over="ignore", invalid="ignore"):
+        for k in range(nsteps):
+            h = dX[k]
+            ri = rho_inv[k]
+            _etd_compute_diag_factors(h, ri, d_int, d_dec, bufs)
+            D2 = D.reshape(n_k, N)
+            Df_PG = D2[P[:, None], g_idx[None, :]]
+            D0_G = D2[0, g_idx]
+
+            ZB = lam[:, None] * (h * D0_G)[None, :]
+            eDB, phi1B, phi2B = _secant_phi_factors(ZB)
+
+            x_PG = eval_F(phc, F_phi, ri, Df_PG, D0_G)
+            F_PG = F_phi.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+            np.multiply(eD[:, None], phc, out=a)
+            np.multiply(phi1[:, None], F_phi, out=scratch_NK)
+            scratch_NK *= h
+            np.add(a, scratch_NK, out=a)
+            a_PG = _secant_left_matmul(
+                V, eDB[:, :, None] * _secant_left_matmul(Vi, x_PG)
+            ) + h * _secant_left_matmul(
+                V, phi1B[:, :, None] * _secant_left_matmul(Vi, F_PG)
+            )
+            a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = a_PG
+
+            eval_F(a, F_a, ri, Df_PG, D0_G)
+            Fa_PG = F_a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+            np.subtract(F_a, F_phi, out=scratch_NK)
+            scratch_NK *= h
+            np.multiply(phi2[:, None], scratch_NK, out=scratch_NK)
+            np.add(a, scratch_NK, out=phc)
+            phc_PG = a_PG + h * _secant_left_matmul(
+                V,
+                phi2B[:, :, None] * _secant_left_matmul(Vi, Fa_PG - F_PG),
+            )
+            phc.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = phc_PG
+
+            if grid_idcs and grid_step < len(grid_idcs) and grid_idcs[grid_step] == k:
+                grid_sol.append(phc.copy())
+                grid_step += 1
+
+    elapsed = time() - start
+    info(
+        2,
+        f"Performance (secant multirhs K={K}): "
+        f"{1e3 * elapsed / float(nsteps):6.2f}ms/iteration "
+        f"({1e3 * elapsed / float(nsteps) / float(K):6.2f}ms/iteration/RHS)",
+    )
+    return phc.copy(), np.array(grid_sol)
 
 
 # ---------------------------------------------------------------------------
@@ -932,16 +1075,16 @@ from collections import namedtuple
 CarouselSchedule = namedtuple(
     "CarouselSchedule",
     [
-        "T",                # int — makespan (outer loop iters)
-        "K",                # int — pipeline width (slots)
-        "K_total",          # int — total pixels packed
-        "slot_assignments", # list[list[int]] — per-slot pixel ids in run order
-        "reset_t_starts",   # (T+1,) int32 — CSR ptrs into reset_j / reset_pixel
-        "reset_j",          # (R,) int32 — slot id of each reset event
-        "reset_pixel",      # (R,) int32 — pixel id whose phi0 to load
+        "T",  # int — makespan (outer loop iters)
+        "K",  # int — pipeline width (slots)
+        "K_total",  # int — total pixels packed
+        "slot_assignments",  # list[list[int]] — per-slot pixel ids in run order
+        "reset_t_starts",  # (T+1,) int32 — CSR ptrs into reset_j / reset_pixel
+        "reset_j",  # (R,) int32 — slot id of each reset event
+        "reset_pixel",  # (R,) int32 — pixel id whose phi0 to load
         "record_t_starts",  # (T+1,) int32 — CSR ptrs into record_j / record_pixel
-        "record_j",         # (K_total,) int32 — slot id of each harvest event
-        "record_pixel",     # (K_total,) int32 — pixel id to record into
+        "record_j",  # (K_total,) int32 — slot id of each harvest event
+        "record_pixel",  # (K_total,) int32 — pixel id to record into
     ],
 )
 
@@ -1117,7 +1260,7 @@ def solv_numpy_etd2_carousel(
     dim = phi_initial.shape[0]
     if dX.shape != (T, K) or rho_inv.shape != (T, K):
         raise ValueError(
-            f"solv_numpy_etd2_carousel: dX/rho_inv must be (T,K)={T,K}; "
+            f"solv_numpy_etd2_carousel: dX/rho_inv must be (T,K)={T, K}; "
             f"got dX={dX.shape}, rho_inv={rho_inv.shape}"
         )
     if phi_initial.shape != (dim, K):
@@ -1210,6 +1353,167 @@ def solv_numpy_etd2_carousel(
         f"waste={waste:.1%})",
     )
 
+    return sol_pixel
+
+
+def solv_numpy_etd2_secant_carousel(
+    int_m,
+    dec_m,
+    dX,
+    rho_inv,
+    phi_initial,
+    schedule,
+    phi0_per_pixel,
+    sec_ops,
+):
+    """Cap-homogeneous NumPy secant carousel.
+
+    This is the per-path/RHS lift of :func:`solv_numpy_etd2_secant`.
+    Every pixel scheduled into this invocation has the same resolved
+    secant operator, while ``dX`` and ``rho_inv`` remain independent per
+    pipeline slot.  Core groups heterogeneous sky columns by cap before
+    calling this kernel and scatters the returned local pixel order back
+    to the original full-sky order.
+    """
+    T = schedule.T
+    K = schedule.K
+    K_total = schedule.K_total
+    dim = phi_initial.shape[0]
+    if dX.shape != (T, K) or rho_inv.shape != (T, K):
+        raise ValueError(
+            f"solv_numpy_etd2_secant_carousel: dX/rho_inv must be "
+            f"(T,K)=({T},{K}); got dX={dX.shape}, rho_inv={rho_inv.shape}"
+        )
+    if phi_initial.shape != (dim, K):
+        raise ValueError(
+            f"solv_numpy_etd2_secant_carousel: phi_initial must be "
+            f"(dim,K)=({dim},{K}); got {phi_initial.shape}"
+        )
+    if phi0_per_pixel.shape != (dim, K_total):
+        raise ValueError(
+            f"solv_numpy_etd2_secant_carousel: phi0_per_pixel must be "
+            f"(dim,K_total)=({dim},{K_total}); got {phi0_per_pixel.shape}"
+        )
+
+    d_int, d_dec, int_off, dec_off = _etd_split_cache(int_m, dec_m)
+    if not sp.isspmatrix_csr(int_off):
+        int_off = int_off.tocsr()
+    if not sp.isspmatrix_csr(dec_off):
+        dec_off = dec_off.tocsr()
+
+    P = np.asarray(sec_ops["P"], dtype=np.intp)
+    T_P = np.asarray(sec_ops["T_P"], dtype=np.float64)
+    T_PP = np.asarray(sec_ops["T_PP"], dtype=np.float64)
+    V = np.asarray(sec_ops["V"], dtype=np.float64)
+    Vi = np.asarray(sec_ops["Vi"], dtype=np.float64)
+    lam = np.asarray(sec_ops["lam"], dtype=np.float64)
+    g_idx = np.asarray(sec_ops["gate_idx"], dtype=np.intp)
+    n_k = int(sec_ops["n_k"])
+    N = dim // n_k
+    if n_k * N != dim:
+        raise ValueError("state dim not divisible by secant n_k")
+
+    phc = np.array(phi_initial, dtype=np.float64, copy=True)
+    F_phi = np.empty((dim, K), dtype=np.float64)
+    F_a = np.empty((dim, K), dtype=np.float64)
+    a = np.empty((dim, K), dtype=np.float64)
+    w = np.empty((dim, K), dtype=np.float64)
+    scratch_NK = np.empty((dim, K), dtype=np.float64)
+    bufs = _etd_step_buffers_multipath(dim, K)
+    eD = bufs["eD"]
+    phi1 = bufs["phi1"]
+    phi2 = bufs["phi2"]
+    D = bufs["D"]
+    sol_pixel = np.empty((dim, K_total), dtype=np.float64)
+
+    def eval_F(xbuf, Fbuf, ri_K, Df_PG, D0_G):
+        X3 = xbuf.reshape(n_k, N, K)
+        XG = X3[:, g_idx, :]
+        YG = _secant_left_matmul(T_P, XG)
+        np.copyto(w, xbuf)
+        W3 = w.reshape(n_k, N, K)
+        W3[P[:, None], g_idx[None, :], :] += YG
+        np.copyto(Fbuf, int_off.dot(w))
+        ri_dec = dec_off.dot(w)
+        ri_dec *= ri_K[None, :]
+        np.add(Fbuf, ri_dec, out=Fbuf)
+        x_PG = XG[P, :, :]
+        SPxP = x_PG + _secant_left_matmul(T_PP, x_PG)
+        w_PG = x_PG + YG
+        delta = Df_PG * w_PG - D0_G[None, :, :] * SPxP
+        F3 = Fbuf.reshape(n_k, N, K)
+        F3[P[:, None], g_idx[None, :], :] += delta
+        return x_PG
+
+    rs = schedule.reset_t_starts
+    rj = schedule.reset_j
+    rp = schedule.reset_pixel
+    cs = schedule.record_t_starts
+    cj = schedule.record_j
+    cpix = schedule.record_pixel
+
+    from time import time
+
+    start = time()
+    with np.errstate(over="ignore", invalid="ignore"):
+        for step in range(T):
+            h_K = dX[step]
+            ri_K = rho_inv[step]
+            _etd_compute_diag_factors_multipath(h_K, ri_K, d_int, d_dec, bufs)
+            D3 = D.reshape(n_k, N, K)
+            Df_PG = D3[P[:, None], g_idx[None, :], :]
+            D0_G = D3[0, g_idx, :]
+
+            ZB = lam[:, None, None] * (h_K[None, None, :] * D0_G[None, :, :])
+            eDB, phi1B, phi2B = _secant_phi_factors(ZB)
+
+            x_PG = eval_F(phc, F_phi, ri_K, Df_PG, D0_G)
+            F_PG = F_phi.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+            np.multiply(eD, phc, out=a)
+            np.multiply(phi1, F_phi, out=scratch_NK)
+            scratch_NK *= h_K[None, :]
+            np.add(a, scratch_NK, out=a)
+            a_PG = _secant_left_matmul(V, eDB * _secant_left_matmul(Vi, x_PG)) + h_K[
+                None, None, :
+            ] * _secant_left_matmul(V, phi1B * _secant_left_matmul(Vi, F_PG))
+            frozen = h_K == 0.0
+            if np.any(frozen):
+                # A padded carousel slot is a strict identity map.  Avoid
+                # repeatedly round-tripping it through V/Vi during a long
+                # tail after its final pixel was harvested.
+                a_PG[:, :, frozen] = x_PG[:, :, frozen]
+            a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = a_PG
+
+            eval_F(a, F_a, ri_K, Df_PG, D0_G)
+            Fa_PG = F_a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+            np.subtract(F_a, F_phi, out=scratch_NK)
+            scratch_NK *= h_K[None, :]
+            np.multiply(phi2, scratch_NK, out=scratch_NK)
+            np.add(a, scratch_NK, out=phc)
+            phc_PG = a_PG + h_K[None, None, :] * _secant_left_matmul(
+                V, phi2B * _secant_left_matmul(Vi, Fa_PG - F_PG)
+            )
+            if np.any(frozen):
+                phc_PG[:, :, frozen] = x_PG[:, :, frozen]
+            phc.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = phc_PG
+
+            for r in range(cs[step], cs[step + 1]):
+                sol_pixel[:, cpix[r]] = phc[:, cj[r]]
+            for r in range(rs[step], rs[step + 1]):
+                phc[:, rj[r]] = phi0_per_pixel[:, rp[r]]
+
+    elapsed = time() - start
+    useful = int(np.count_nonzero(dX))
+    waste = 1.0 - useful / float(T * K) if (T * K) else 0.0
+    info(
+        2,
+        f"Performance (secant carousel K={K}, K_total={K_total}, T={T}): "
+        f"{1e3 * elapsed / float(T):6.2f}ms/iteration "
+        f"({1e3 * elapsed / float(T) / float(K):6.2f}ms/iter/slot, "
+        f"waste={waste:.1%})",
+    )
     return sol_pixel
 
 
@@ -1615,25 +1919,53 @@ def _set_mkl_argtypes(mkl):
 
     # fp64
     mkl.mkl_sparse_d_mv.argtypes = [
-        c_int, fl64, c_void_p, _MklMatrixDescr,
-        POINTER(fl64), fl64, POINTER(fl64),
+        c_int,
+        fl64,
+        c_void_p,
+        _MklMatrixDescr,
+        POINTER(fl64),
+        fl64,
+        POINTER(fl64),
     ]
     mkl.mkl_sparse_d_mv.restype = c_int
     mkl.mkl_sparse_d_mm.argtypes = [
-        c_int, fl64, c_void_p, _MklMatrixDescr, c_int,
-        POINTER(fl64), c_int, c_int, fl64, POINTER(fl64), c_int,
+        c_int,
+        fl64,
+        c_void_p,
+        _MklMatrixDescr,
+        c_int,
+        POINTER(fl64),
+        c_int,
+        c_int,
+        fl64,
+        POINTER(fl64),
+        c_int,
     ]
     mkl.mkl_sparse_d_mm.restype = c_int
     # fp32
     if hasattr(mkl, "mkl_sparse_s_mv"):
         mkl.mkl_sparse_s_mv.argtypes = [
-            c_int, fl32, c_void_p, _MklMatrixDescr,
-            POINTER(fl32), fl32, POINTER(fl32),
+            c_int,
+            fl32,
+            c_void_p,
+            _MklMatrixDescr,
+            POINTER(fl32),
+            fl32,
+            POINTER(fl32),
         ]
         mkl.mkl_sparse_s_mv.restype = c_int
         mkl.mkl_sparse_s_mm.argtypes = [
-            c_int, fl32, c_void_p, _MklMatrixDescr, c_int,
-            POINTER(fl32), c_int, c_int, fl32, POINTER(fl32), c_int,
+            c_int,
+            fl32,
+            c_void_p,
+            _MklMatrixDescr,
+            c_int,
+            POINTER(fl32),
+            c_int,
+            c_int,
+            fl32,
+            POINTER(fl32),
+            c_int,
         ]
         mkl.mkl_sparse_s_mm.restype = c_int
 
@@ -2243,12 +2575,12 @@ def solv_mkl_etd2_secant(
             n_padded = max(n_padded, m.n_padded)
 
     P = sec_ops["P"]
-    T_P = sec_ops["T_P"]          # (n_P, n_k)
-    T_PP = sec_ops["T_PP"]        # (n_P, n_P)
+    T_P = sec_ops["T_P"]  # (n_P, n_k)
+    T_PP = sec_ops["T_PP"]  # (n_P, n_P)
     V = sec_ops["V"]
     Vi = sec_ops["Vi"]
-    lam = sec_ops["lam"]          # (n_P,)
-    g_idx = sec_ops["gate_idx"]   # (n_g,)
+    lam = sec_ops["lam"]  # (n_P,)
+    g_idx = sec_ops["gate_idx"]  # (n_g,)
     n_k = sec_ops["n_k"]
     N = dim // n_k
     assert n_k * N == dim, "state dim not divisible by n_k"
@@ -2286,8 +2618,8 @@ def solv_mkl_etd2_secant(
         """F <- off-diagonal + coupling remainder of the operator at x
         (SpMVs act on w = x + T_gated x); returns the gathered x_PG."""
         x2 = x_v.reshape(n_k, N)
-        XG = x2[:, g_idx]                     # (n_k, n_g)
-        YG = T_P @ XG                         # coupling u on (P, g)
+        XG = x2[:, g_idx]  # (n_k, n_g)
+        YG = T_P @ XG  # coupling u on (P, g)
         np.copyto(w_v, x_v)
         w_v.reshape(n_k, N)[ixPG] += YG
         if not int_off_empty:
@@ -2318,8 +2650,8 @@ def solv_mkl_etd2_secant(
 
             _etd_compute_diag_factors(h, ri, d_int, d_dec, bufs)
             D2 = D.reshape(n_k, N)
-            Df_PG = D2[ixPG]                  # full diag on coupled plane
-            D0_G = D2[0, g_idx]               # k-shared part (kappa = 0)
+            Df_PG = D2[ixPG]  # full diag on coupled plane
+            D0_G = D2[0, g_idx]  # k-shared part (kappa = 0)
 
             # block factors for the exact slot: f(h * D0_i * lam_j)
             ZB = lam[:, None] * (h * D0_G)[None, :]
@@ -2658,12 +2990,12 @@ def solv_cuda_etd2_secant(nsteps, dX, rho_inv, ctx, phi, grid_idcs, sec_ops):
 
     # Upload the constant operator set (few tens of KB — negligible).
     P = cp.asarray(sec_ops["P"])
-    T_P = cp.asarray(sec_ops["T_P"], dtype=fl_pr)      # (n_P, n_k)
-    T_PP = cp.asarray(sec_ops["T_PP"], dtype=fl_pr)    # (n_P, n_P)
+    T_P = cp.asarray(sec_ops["T_P"], dtype=fl_pr)  # (n_P, n_k)
+    T_PP = cp.asarray(sec_ops["T_PP"], dtype=fl_pr)  # (n_P, n_P)
     V = cp.asarray(sec_ops["V"], dtype=fl_pr)
     Vi = cp.asarray(sec_ops["Vi"], dtype=fl_pr)
-    lam = cp.asarray(sec_ops["lam"], dtype=fl_pr)      # (n_P,)
-    g_idx = cp.asarray(sec_ops["gate_idx"])            # (n_g,)
+    lam = cp.asarray(sec_ops["lam"], dtype=fl_pr)  # (n_P,)
+    g_idx = cp.asarray(sec_ops["gate_idx"])  # (n_g,)
     ixPG = cp.ix_(P, g_idx)
 
     cu_phc = ctx.cu_phc
@@ -2682,18 +3014,22 @@ def solv_cuda_etd2_secant(nsteps, dX, rho_inv, ctx, phi, grid_idcs, sec_ops):
         """Elementwise exp/phi1/phi2 with Taylor patches (cupy)."""
         safe = cp.where(ZB == 0.0, fl_pr(1.0), ZB)
         e1 = cp.expm1(ZB)
-        phi1B = cp.where(cp.abs(ZB) > _PHI1_SMALL, e1 / safe,
-                         1.0 + ZB * (0.5 + ZB * _INV_6))
-        phi2B = cp.where(cp.abs(ZB) > _PHI2_SMALL, (e1 - ZB) / (safe * safe),
-                         0.5 + ZB * (_INV_6 + ZB * _INV_24))
+        phi1B = cp.where(
+            cp.abs(ZB) > _PHI1_SMALL, e1 / safe, 1.0 + ZB * (0.5 + ZB * _INV_6)
+        )
+        phi2B = cp.where(
+            cp.abs(ZB) > _PHI2_SMALL,
+            (e1 - ZB) / (safe * safe),
+            0.5 + ZB * (_INV_6 + ZB * _INV_24),
+        )
         return cp.exp(ZB), phi1B, phi2B
 
     def eval_F(xbuf, Fbuf, ri, Df_PG, D0_G):
         """Fbuf <- off-diagonal + coupling remainder at xbuf; returns the
         gathered x_PG. SpMVs act on w = xbuf + T_gated xbuf."""
         X2 = xbuf.reshape(n_k, N)
-        XG = X2[:, g_idx]                     # (n_k, n_g)
-        YG = T_P @ XG                         # coupling u on (P, g)
+        XG = X2[:, g_idx]  # (n_k, n_g)
+        YG = T_P @ XG  # coupling u on (P, g)
         cu_w[:] = xbuf
         W2 = cu_w.reshape(n_k, N)
         W2[ixPG] = W2[ixPG] + YG
@@ -2727,8 +3063,8 @@ def solv_cuda_etd2_secant(nsteps, dX, rho_inv, ctx, phi, grid_idcs, sec_ops):
         phi1 = ctx.cu_phi1
         phi2 = ctx.cu_phi2
         D2 = ctx.cu_D.reshape(n_k, N)
-        Df_PG = D2[ixPG]                      # full diag on coupled plane
-        D0_G = D2[0, g_idx]                   # k-shared part (kappa = 0)
+        Df_PG = D2[ixPG]  # full diag on coupled plane
+        D0_G = D2[0, g_idx]  # k-shared part (kappa = 0)
 
         # block factors for the exact slot: f(h * D0_i * lam_j)
         ZB = lam[:, None] * (h * D0_G)[None, :]
@@ -2935,20 +3271,28 @@ class CudaEtd2MultiRHSContext:
     * ``fl_pr``: ``cp.float32`` or ``cp.float64`` — buffer dtype.
 
     Constructed once per ``MCEqRun`` per (dtype, K) pair and cached in
-    ``MCEqRun._cuda_etd2_multirhs_cache`` so the cuSPARSE handle and the
-    state buffers are reused across ``solve_multirhs`` / ``solve_fullsky``
-    calls.
+    ``MCEqRun._cuda_etd2_multirhs_cache``. Contexts with different K but the
+    same matrices/device/precision share the immutable CSR matrices and
+    diagonals; only K-shaped state/scratch buffers are distinct.
     """
 
-    def __init__(self, int_off, dec_off, d_int, d_dec, K, device_id, fp_precision):
+    def __init__(
+        self,
+        int_off,
+        dec_off,
+        d_int,
+        d_dec,
+        K,
+        device_id,
+        fp_precision,
+        shared_static=None,
+    ):
         _preload_nvidia_pip_libs()
         try:
             import cupy as cp
             import cupyx.scipy.sparse as cusp
         except ImportError as e:
-            raise RuntimeError(
-                "CudaEtd2MultiRHSContext: CuPy is not available."
-            ) from e
+            raise RuntimeError("CudaEtd2MultiRHSContext: CuPy is not available.") from e
 
         if fp_precision == 32:
             fl_pr = cp.float32
@@ -2971,19 +3315,45 @@ class CudaEtd2MultiRHSContext:
         if self.K < 1:
             raise ValueError(f"K must be >= 1, got {self.K}")
 
-        # cuSPARSE CSR copies — None when empty (matches the single-RHS
-        # context's convention; the kernel skips empty SpMMs).
-        self.cu_int_off = (
-            cusp.csr_matrix(int_off, dtype=fl_pr) if int_off.nnz else None
-        )
-        self.cu_dec_off = (
-            cusp.csr_matrix(dec_off, dtype=fl_pr) if dec_off.nnz else None
-        )
-        # Diagonals stay on device in fp64-precision arithmetic; we cast
-        # down to fl_pr for the phi/eD pipeline (sufficient — the Mac fp32
-        # stability test holds at 1e-4 rel-err with the same arithmetic).
-        self.cu_d_int = cp.asarray(d_int, dtype=fl_pr)
-        self.cu_d_dec = cp.asarray(d_dec, dtype=fl_pr)
+        # cuSPARSE matrices and diagonals do not depend on K. Share them with
+        # another width context when core has established identical host matrix
+        # identities, device and precision. Direct array/matrix references keep
+        # the storage alive even if the original cache entry is later replaced.
+        self._shared_static = shared_static
+        if shared_static is None:
+            self.cu_int_off = (
+                cusp.csr_matrix(int_off, dtype=fl_pr) if int_off.nnz else None
+            )
+            self.cu_dec_off = (
+                cusp.csr_matrix(dec_off, dtype=fl_pr) if dec_off.nnz else None
+            )
+            # The host diagonals are fp64; device storage follows the context
+            # precision, matching the existing phi/eD pipeline.
+            self.cu_d_int = cp.asarray(d_int, dtype=fl_pr)
+            self.cu_d_dec = cp.asarray(d_dec, dtype=fl_pr)
+        else:
+            if int(shared_static.device_id) != self.device_id:
+                raise ValueError(
+                    "CudaEtd2MultiRHSContext: shared_static device mismatch"
+                )
+            if shared_static.fl_pr is not fl_pr:
+                raise ValueError(
+                    "CudaEtd2MultiRHSContext: shared_static precision mismatch"
+                )
+            if int(shared_static.dim) != dim:
+                raise ValueError(
+                    "CudaEtd2MultiRHSContext: shared_static dimension mismatch"
+                )
+            if (shared_static.cu_int_off is None) != (int_off.nnz == 0) or (
+                shared_static.cu_dec_off is None
+            ) != (dec_off.nnz == 0):
+                raise ValueError(
+                    "CudaEtd2MultiRHSContext: shared_static sparsity mismatch"
+                )
+            self.cu_int_off = shared_static.cu_int_off
+            self.cu_dec_off = shared_static.cu_dec_off
+            self.cu_d_int = shared_static.cu_d_int
+            self.cu_d_dec = shared_static.cu_d_dec
 
         # (dim, K) state + scratch.
         self.cu_phc = cp.empty((dim, self.K), dtype=fl_pr)
@@ -2992,10 +3362,14 @@ class CudaEtd2MultiRHSContext:
         self.cu_a = cp.empty((dim, self.K), dtype=fl_pr)
         # dec_off scratch only used when dec_off is non-empty.
         self.cu_dec_phc = (
-            cp.empty((dim, self.K), dtype=fl_pr) if self.cu_dec_off is not None else None
+            cp.empty((dim, self.K), dtype=fl_pr)
+            if self.cu_dec_off is not None
+            else None
         )
         self.cu_dec_a = (
-            cp.empty((dim, self.K), dtype=fl_pr) if self.cu_dec_off is not None else None
+            cp.empty((dim, self.K), dtype=fl_pr)
+            if self.cu_dec_off is not None
+            else None
         )
 
         # (dim,) diag-factor buffers — shared across the K columns.
@@ -3030,6 +3404,135 @@ class CudaEtd2MultiRHSContext:
         self.cu_ri_K = cp.empty(K, dtype=self.fl_pr)
         # Row view for broadcast.
         self.cu_h_K_row = self.cu_h_K.reshape(1, K)
+
+
+def _cuda_secant_multirhs_state(ctx, sec_ops):
+    """Validate/cache a fixed secant operator for a CUDA multi-RHS context.
+
+    A carousel invocation is cap-homogeneous: every pixel propagated by
+    the call uses the same ``sec_ops``.  The operator arrays are small, but
+    uploading them and reallocating the full ``(dim, K)`` ``w`` plane for
+    every cap group is avoidable.  Cache operator uploads by an exact hash
+    of the normalized host arrays, and keep one context-wide ``w`` buffer.
+
+    Returns ``(ops, cu_w, N)`` where ``ops`` is a namespace of device
+    arrays and ``N = dim / n_k`` is the per-mode state dimension.
+    """
+    import hashlib
+
+    cp = ctx.cp
+    fl_pr = ctx.fl_pr
+
+    try:
+        n_k = int(sec_ops["n_k"])
+        P_h = np.ascontiguousarray(sec_ops["P"], dtype=np.int64)
+        g_h = np.ascontiguousarray(sec_ops["gate_idx"], dtype=np.int64)
+        T_P_h = np.ascontiguousarray(sec_ops["T_P"])
+        T_PP_h = np.ascontiguousarray(sec_ops["T_PP"])
+        V_h = np.ascontiguousarray(sec_ops["V"])
+        Vi_h = np.ascontiguousarray(sec_ops["Vi"])
+        lam_h = np.ascontiguousarray(sec_ops["lam"])
+    except KeyError as exc:
+        raise ValueError(f"sec_ops is missing required entry {exc.args[0]!r}") from exc
+
+    if n_k < 1 or ctx.dim % n_k:
+        raise ValueError(
+            "CUDA secant multi-RHS: state dim must be divisible by "
+            f"sec_ops['n_k'] (dim={ctx.dim}, n_k={n_k})"
+        )
+    N = ctx.dim // n_k
+    if P_h.ndim != 1 or g_h.ndim != 1:
+        raise ValueError("CUDA secant multi-RHS: P and gate_idx must be 1-D")
+    n_P = P_h.size
+    expected = {
+        "T_P": (n_P, n_k),
+        "T_PP": (n_P, n_P),
+        "V": (n_P, n_P),
+        "Vi": (n_P, n_P),
+        "lam": (n_P,),
+    }
+    actual = {
+        "T_P": T_P_h.shape,
+        "T_PP": T_PP_h.shape,
+        "V": V_h.shape,
+        "Vi": Vi_h.shape,
+        "lam": lam_h.shape,
+    }
+    bad = [name for name in expected if actual[name] != expected[name]]
+    if bad:
+        details = ", ".join(
+            f"{name}={actual[name]} (expected {expected[name]})" for name in bad
+        )
+        raise ValueError(
+            f"CUDA secant multi-RHS: inconsistent sec_ops shapes: {details}"
+        )
+    if P_h.size and (P_h.min() < 0 or P_h.max() >= n_k):
+        raise ValueError(f"CUDA secant multi-RHS: P indices must lie in [0, {n_k})")
+    if g_h.size and (g_h.min() < 0 or g_h.max() >= N):
+        raise ValueError(
+            f"CUDA secant multi-RHS: gate_idx indices must lie in [0, {N})"
+        )
+
+    # Hash values, shapes and source dtypes.  This remains correct if a
+    # caller mutates/rebuilds a dict in place, unlike an id(sec_ops) key.
+    digest = hashlib.sha256()
+    digest.update(np.asarray([n_k], dtype=np.int64).tobytes())
+    normalized = (
+        ("P", P_h),
+        ("gate_idx", g_h),
+        ("T_P", T_P_h),
+        ("T_PP", T_PP_h),
+        ("V", V_h),
+        ("Vi", Vi_h),
+        ("lam", lam_h),
+    )
+    for name, arr in normalized:
+        digest.update(name.encode("ascii"))
+        digest.update(arr.dtype.str.encode("ascii"))
+        digest.update(np.asarray(arr.shape, dtype=np.int64).tobytes())
+        digest.update(arr.tobytes(order="C"))
+    cache_key = (fl_pr.__name__, digest.digest())
+
+    cache = getattr(ctx, "_cuda_secant_ops_cache", None)
+    if cache is None:
+        cache = {}
+        ctx._cuda_secant_ops_cache = cache
+    ops = cache.get(cache_key)
+    if ops is None:
+        ops = SimpleNamespace(
+            n_k=n_k,
+            P=cp.asarray(P_h),
+            gate_idx=cp.asarray(g_h),
+            T_P=cp.asarray(T_P_h, dtype=fl_pr),
+            T_PP=cp.asarray(T_PP_h, dtype=fl_pr),
+            V=cp.asarray(V_h, dtype=fl_pr),
+            Vi=cp.asarray(Vi_h, dtype=fl_pr),
+            lam=cp.asarray(lam_h, dtype=fl_pr),
+        )
+        cache[cache_key] = ops
+
+    cu_w = getattr(ctx, "_cuda_secant_w", None)
+    if cu_w is None or cu_w.shape != (ctx.dim, ctx.K) or cu_w.dtype != fl_pr:
+        cu_w = cp.empty((ctx.dim, ctx.K), dtype=fl_pr)
+        ctx._cuda_secant_w = cu_w
+    return ops, cu_w, N
+
+
+def _cuda_secant_phi_factors(cp, fl_pr, ZB):
+    """CUDA exp/phi1/phi2 factors for a secant exact-block argument."""
+    safe = cp.where(ZB == 0.0, fl_pr(1.0), ZB)
+    e1 = cp.expm1(ZB)
+    phi1B = cp.where(
+        cp.abs(ZB) > _PHI1_SMALL,
+        e1 / safe,
+        1.0 + ZB * (0.5 + ZB * _INV_6),
+    )
+    phi2B = cp.where(
+        cp.abs(ZB) > _PHI2_SMALL,
+        (e1 - ZB) / (safe * safe),
+        0.5 + ZB * (_INV_6 + ZB * _INV_24),
+    )
+    return cp.exp(ZB), phi1B, phi2B
 
 
 def solv_cuda_etd2_multirhs(
@@ -3172,9 +3675,211 @@ def solv_cuda_etd2_multirhs(
     return phc_host, grid_arr
 
 
-def solv_cuda_etd2_carousel(
-    ctx, dX, rho_inv, phi_initial, schedule, phi0_per_pixel
+def solv_cuda_etd2_secant_multirhs(
+    nsteps,
+    dX,
+    rho_inv,
+    ctx,
+    phi,
+    grid_idcs,
+    sec_ops,
 ):
+    """Shared-path CUDA multi-RHS ETD2 with fixed sec(theta) coupling.
+
+    This is the GPU lift of :func:`solv_numpy_etd2_secant_multirhs`.
+    Sparse stages remain one cuSPARSE SpMM over ``(dim, K)``.  The mode
+    transforms flatten the logical ``(n_P, n_gated, K)`` plane so each
+    transform is one dense GEMM, rather than one launch per RHS.
+    """
+    cp = ctx.cp
+    fl_pr = ctx.fl_pr
+    Kset = _cuda_etd2_kernels()
+
+    phi = np.asarray(phi)
+    if phi.ndim != 2:
+        raise ValueError(
+            "solv_cuda_etd2_secant_multirhs: phi must be 2-D (dim, K), "
+            f"got shape {phi.shape}"
+        )
+    dim, K = phi.shape
+    if dim != ctx.dim or K != ctx.K:
+        raise ValueError(
+            "solv_cuda_etd2_secant_multirhs: phi must match ctx shape "
+            f"({ctx.dim}, {ctx.K}); got {phi.shape}"
+        )
+    dX = np.asarray(dX)
+    rho_inv = np.asarray(rho_inv)
+    if dX.shape != (nsteps,) or rho_inv.shape != (nsteps,):
+        raise ValueError(
+            "solv_cuda_etd2_secant_multirhs: dX/rho_inv must be "
+            f"({nsteps},); got dX={dX.shape}, rho_inv={rho_inv.shape}"
+        )
+
+    cp.cuda.Device(ctx.device_id).use()
+    ops, cu_w, N = _cuda_secant_multirhs_state(ctx, sec_ops)
+    if ops.P.size == 0 or ops.gate_idx.size == 0:
+        return solv_cuda_etd2_multirhs(nsteps, dX, rho_inv, ctx, phi, grid_idcs)
+
+    n_k = ops.n_k
+    P = ops.P
+    g_idx = ops.gate_idx
+    T_P = ops.T_P
+    T_PP = ops.T_PP
+    V = ops.V
+    Vi = ops.Vi
+    lam = ops.lam
+
+    cu_phc = ctx.cu_phc
+    cu_F_phi = ctx.cu_F_phi
+    cu_F_a = ctx.cu_F_a
+    cu_a = ctx.cu_a
+    cu_dec_phc = ctx.cu_dec_phc
+    cu_dec_a = ctx.cu_dec_a
+    cu_D = ctx.cu_D
+    cu_hD = ctx.cu_hD
+    cu_eD = ctx.cu_eD
+    cu_phi1 = ctx.cu_phi1
+    cu_phi2 = ctx.cu_phi2
+    cu_phc[:] = cp.asarray(phi, dtype=fl_pr)
+
+    # Diagonal slices needed by the coupled exact slot.  They are shared
+    # by all RHS columns; only the scalar rho_inv changes per step.
+    d_int_2 = ctx.cu_d_int.reshape(n_k, N)
+    d_dec_2 = ctx.cu_d_dec.reshape(n_k, N)
+    d_int_PG = d_int_2[P[:, None], g_idx[None, :]]
+    d_dec_PG = d_dec_2[P[:, None], g_idx[None, :]]
+    d_int_0G = d_int_2[0, g_idx]
+    d_dec_0G = d_dec_2[0, g_idx]
+
+    int_off_empty = ctx.cu_int_off is None
+    dec_off_empty = ctx.cu_dec_off is None
+
+    def eval_F(xbuf, Fbuf, dec_scratch, ri, Df_PG, D0_G):
+        X3 = xbuf.reshape(n_k, N, K)
+        XG = X3[:, g_idx, :]
+        YG = _secant_left_matmul(T_P, XG)
+        cp.copyto(cu_w, xbuf)
+        W3 = cu_w.reshape(n_k, N, K)
+        W3[P[:, None], g_idx[None, :], :] = W3[P[:, None], g_idx[None, :], :] + YG
+        if not int_off_empty:
+            cp.copyto(Fbuf, ctx.cu_int_off @ cu_w)
+        else:
+            Fbuf.fill(0)
+        if not dec_off_empty:
+            cp.copyto(dec_scratch, ctx.cu_dec_off @ cu_w)
+            dec_scratch *= ri
+            Fbuf += dec_scratch
+        x_PG = XG[P, :, :]
+        SPxP = x_PG + _secant_left_matmul(T_PP, x_PG)
+        w_PG = x_PG + YG
+        delta = Df_PG[:, :, None] * w_PG - D0_G[None, :, None] * SPxP
+        F3 = Fbuf.reshape(n_k, N, K)
+        F3[P[:, None], g_idx[None, :], :] = F3[P[:, None], g_idx[None, :], :] + delta
+        return x_PG
+
+    grid_sol_gpu = []
+    grid_step = 0
+
+    from time import time
+
+    start = time()
+    for step in range(nsteps):
+        h = fl_pr(dX[step])
+        ri = fl_pr(rho_inv[step])
+
+        # A requested snapshot at X_start creates an h=0 step.  Skip it
+        # explicitly: V @ Vi is only numerically identity, while a frozen
+        # ETD2 step must be exactly identity.
+        if float(h) == 0.0:
+            if (
+                grid_idcs
+                and grid_step < len(grid_idcs)
+                and grid_idcs[grid_step] == step
+            ):
+                grid_sol_gpu.append(cu_phc.copy())
+                grid_step += 1
+            continue
+
+        if fl_pr is cp.float32:
+            Kset.phi_compute_multipath_f64diag(
+                ctx.cu_d_int,
+                ctx.cu_d_dec,
+                h,
+                ri,
+                cu_eD,
+                cu_phi1,
+                cu_phi2,
+            )
+        else:
+            cp.multiply(ctx.cu_d_dec, ri, out=cu_D)
+            cp.add(cu_D, ctx.cu_d_int, out=cu_D)
+            cp.multiply(cu_D, h, out=cu_hD)
+            cp.exp(cu_hD, out=cu_eD)
+            Kset.phi_compute(cu_hD, cu_eD, cu_eD, cu_phi1, cu_phi2)
+
+        Df_PG = d_int_PG + ri * d_dec_PG
+        D0_G = d_int_0G + ri * d_dec_0G
+        ZB = lam[:, None] * (h * D0_G)[None, :]
+        eDB, phi1B, phi2B = _cuda_secant_phi_factors(cp, fl_pr, ZB)
+
+        x_PG = eval_F(cu_phc, cu_F_phi, cu_dec_phc, ri, Df_PG, D0_G)
+        F_PG = cu_F_phi.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+        Kset.post_apply1(
+            cu_eD[:, None],
+            cu_phc,
+            cu_phi1[:, None],
+            cu_F_phi,
+            h,
+            cu_a,
+        )
+        a_PG = _secant_left_matmul(
+            V, eDB[:, :, None] * _secant_left_matmul(Vi, x_PG)
+        ) + h * _secant_left_matmul(
+            V, phi1B[:, :, None] * _secant_left_matmul(Vi, F_PG)
+        )
+        cu_a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = a_PG
+
+        eval_F(cu_a, cu_F_a, cu_dec_a, ri, Df_PG, D0_G)
+        Fa_PG = cu_F_a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+        Kset.post_apply2(
+            cu_a,
+            cu_F_a,
+            cu_F_phi,
+            cu_phi2[:, None],
+            h,
+            cu_phc,
+        )
+        phc_PG = a_PG + h * _secant_left_matmul(
+            V,
+            phi2B[:, :, None] * _secant_left_matmul(Vi, Fa_PG - F_PG),
+        )
+        cu_phc.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = phc_PG
+
+        if grid_idcs and grid_step < len(grid_idcs) and grid_idcs[grid_step] == step:
+            grid_sol_gpu.append(cu_phc.copy())
+            grid_step += 1
+
+    cp.cuda.Stream.null.synchronize()
+    phc_host = cp.asnumpy(cu_phc)
+    if grid_sol_gpu:
+        grid_arr = cp.asnumpy(cp.stack(grid_sol_gpu))
+    else:
+        grid_arr = np.array([])
+
+    elapsed = time() - start
+    per_step = elapsed / float(nsteps) if nsteps else 0.0
+    info(
+        2,
+        f"Performance (cuda secant multirhs dtype={fl_pr.__name__} K={K}): "
+        f"{1e3 * per_step:6.2f}ms/iteration "
+        f"({1e3 * per_step / float(K):6.2f}ms/iteration/RHS)",
+    )
+    return phc_host, grid_arr
+
+
+def solv_cuda_etd2_carousel(ctx, dX, rho_inv, phi_initial, schedule, phi0_per_pixel):
     """ETD2RK on cuSPARSE via cupy — Stage 5 LPT carousel multipath.
 
     Per-step body is structurally identical to
@@ -3211,8 +3916,7 @@ def solv_cuda_etd2_carousel(
     dim = ctx.dim
     if K != ctx.K:
         raise ValueError(
-            f"solv_cuda_etd2_carousel: schedule.K ({K}) does not match "
-            f"ctx.K ({ctx.K})"
+            f"solv_cuda_etd2_carousel: schedule.K ({K}) does not match ctx.K ({ctx.K})"
         )
     if phi_initial.shape != (dim, K):
         raise ValueError(
@@ -3262,7 +3966,7 @@ def solv_cuda_etd2_carousel(
     rp_d = cp.asarray(schedule.reset_pixel, dtype=cp.int32)
     cj_d = cp.asarray(schedule.record_j, dtype=cp.int32)
     cp_d = cp.asarray(schedule.record_pixel, dtype=cp.int32)
-    rs = schedule.reset_t_starts   # host int32, used for the per-step gate
+    rs = schedule.reset_t_starts  # host int32, used for the per-step gate
     cs = schedule.record_t_starts
 
     int_off_empty = ctx.cu_int_off is None
@@ -3284,12 +3988,10 @@ def solv_cuda_etd2_carousel(
     start = time()
 
     for step in range(T):
-        h_row = dX_d[step : step + 1]    # (1, K) device view
+        h_row = dX_d[step : step + 1]  # (1, K) device view
         ri_row = rho_inv_d[step : step + 1]
 
-        phi_kernel(
-            d_int_col, d_dec_col, h_row, ri_row, cu_eD, cu_phi1, cu_phi2
-        )
+        phi_kernel(d_int_col, d_dec_col, h_row, ri_row, cu_eD, cu_phi1, cu_phi2)
 
         if not int_off_empty:
             cp.copyto(cu_F_phi, ctx.cu_int_off @ cu_phc)
@@ -3338,6 +4040,223 @@ def solv_cuda_etd2_carousel(
         f"waste={waste:.1%})",
     )
 
+    return sol_host
+
+
+def solv_cuda_etd2_secant_carousel(
+    ctx,
+    dX,
+    rho_inv,
+    phi_initial,
+    schedule,
+    phi0_per_pixel,
+    sec_ops,
+):
+    """Cap-homogeneous CUDA carousel with exact sec(theta) blocks.
+
+    Core groups pixels by their resolved secant operator before invoking
+    this kernel.  Paths and initial states remain per pixel; within one
+    invocation the fixed mode operator is applied to every live pipeline
+    slot.  Mode transforms flatten ``(n_P, n_gated, K)`` into one GEMM,
+    while the sparse interaction/decay stages remain cuSPARSE SpMMs.
+    """
+    cp = ctx.cp
+    fl_pr = ctx.fl_pr
+    Kset = _cuda_etd2_kernels()
+
+    T = schedule.T
+    K = schedule.K
+    K_total = schedule.K_total
+    dim = ctx.dim
+    dX = np.asarray(dX)
+    rho_inv = np.asarray(rho_inv)
+    phi_initial = np.asarray(phi_initial)
+    phi0_per_pixel = np.asarray(phi0_per_pixel)
+    if K != ctx.K:
+        raise ValueError(
+            f"solv_cuda_etd2_secant_carousel: schedule.K ({K}) does not "
+            f"match ctx.K ({ctx.K})"
+        )
+    if phi_initial.shape != (dim, K):
+        raise ValueError(
+            "solv_cuda_etd2_secant_carousel: phi_initial must be "
+            f"(dim, K)=({dim}, {K}); got {phi_initial.shape}"
+        )
+    if phi0_per_pixel.shape != (dim, K_total):
+        raise ValueError(
+            "solv_cuda_etd2_secant_carousel: phi0_per_pixel must be "
+            f"(dim, K_total)=({dim}, {K_total}); got {phi0_per_pixel.shape}"
+        )
+    if dX.shape != (T, K) or rho_inv.shape != (T, K):
+        raise ValueError(
+            "solv_cuda_etd2_secant_carousel: dX/rho_inv must be "
+            f"(T, K)=({T}, {K}); got dX={dX.shape}, rho_inv={rho_inv.shape}"
+        )
+
+    cp.cuda.Device(ctx.device_id).use()
+    ctx.ensure_multipath_buffers()
+    ops, cu_w, N = _cuda_secant_multirhs_state(ctx, sec_ops)
+    if ops.P.size == 0 or ops.gate_idx.size == 0:
+        return solv_cuda_etd2_carousel(
+            ctx,
+            dX,
+            rho_inv,
+            phi_initial,
+            schedule,
+            phi0_per_pixel,
+        )
+
+    n_k = ops.n_k
+    P = ops.P
+    g_idx = ops.gate_idx
+    T_P = ops.T_P
+    T_PP = ops.T_PP
+    V = ops.V
+    Vi = ops.Vi
+    lam = ops.lam
+
+    cu_phc = ctx.cu_phc
+    cu_F_phi = ctx.cu_F_phi
+    cu_F_a = ctx.cu_F_a
+    cu_a = ctx.cu_a
+    cu_dec_phc = ctx.cu_dec_phc
+    cu_dec_a = ctx.cu_dec_a
+    cu_eD = ctx.cu_eD_mp
+    cu_phi1 = ctx.cu_phi1_mp
+    cu_phi2 = ctx.cu_phi2_mp
+    cu_phc[:] = cp.asarray(phi_initial, dtype=fl_pr)
+
+    cu_phi0_pp = cp.asarray(phi0_per_pixel, dtype=fl_pr)
+    cu_sol = cp.empty((dim, K_total), dtype=fl_pr)
+    dX_d = cp.asarray(dX, dtype=fl_pr)
+    rho_inv_d = cp.asarray(rho_inv, dtype=fl_pr)
+
+    rj_d = cp.asarray(schedule.reset_j, dtype=cp.int32)
+    rp_d = cp.asarray(schedule.reset_pixel, dtype=cp.int32)
+    cj_d = cp.asarray(schedule.record_j, dtype=cp.int32)
+    cp_d = cp.asarray(schedule.record_pixel, dtype=cp.int32)
+    rs = schedule.reset_t_starts
+    cs = schedule.record_t_starts
+
+    int_off_empty = ctx.cu_int_off is None
+    dec_off_empty = ctx.cu_dec_off is None
+    d_int_col = ctx.cu_d_int.reshape(dim, 1)
+    d_dec_col = ctx.cu_d_dec.reshape(dim, 1)
+    d_int_2 = ctx.cu_d_int.reshape(n_k, N)
+    d_dec_2 = ctx.cu_d_dec.reshape(n_k, N)
+    d_int_PG = d_int_2[P[:, None], g_idx[None, :]]
+    d_dec_PG = d_dec_2[P[:, None], g_idx[None, :]]
+    d_int_0G = d_int_2[0, g_idx]
+    d_dec_0G = d_dec_2[0, g_idx]
+
+    phi_kernel = (
+        Kset.phi_compute_multipath_f64diag
+        if fl_pr is cp.float32
+        else Kset.phi_compute_multipath
+    )
+
+    def eval_F(xbuf, Fbuf, dec_scratch, ri_row, Df_PG, D0_G):
+        X3 = xbuf.reshape(n_k, N, K)
+        XG = X3[:, g_idx, :]
+        YG = _secant_left_matmul(T_P, XG)
+        cp.copyto(cu_w, xbuf)
+        W3 = cu_w.reshape(n_k, N, K)
+        W3[P[:, None], g_idx[None, :], :] = W3[P[:, None], g_idx[None, :], :] + YG
+        if not int_off_empty:
+            cp.copyto(Fbuf, ctx.cu_int_off @ cu_w)
+        else:
+            Fbuf.fill(0)
+        if not dec_off_empty:
+            cp.copyto(dec_scratch, ctx.cu_dec_off @ cu_w)
+            dec_scratch *= ri_row
+            Fbuf += dec_scratch
+        x_PG = XG[P, :, :]
+        SPxP = x_PG + _secant_left_matmul(T_PP, x_PG)
+        w_PG = x_PG + YG
+        delta = Df_PG * w_PG - D0_G[None, :, :] * SPxP
+        F3 = Fbuf.reshape(n_k, N, K)
+        F3[P[:, None], g_idx[None, :], :] = F3[P[:, None], g_idx[None, :], :] + delta
+        return x_PG
+
+    from time import time
+
+    start = time()
+    for step in range(T):
+        h_row = dX_d[step : step + 1]
+        ri_row = rho_inv_d[step : step + 1]
+        h_3 = h_row.reshape(1, 1, K)
+        active_3 = h_3 != 0
+
+        phi_kernel(
+            d_int_col,
+            d_dec_col,
+            h_row,
+            ri_row,
+            cu_eD,
+            cu_phi1,
+            cu_phi2,
+        )
+
+        Df_PG = d_int_PG[:, :, None] + d_dec_PG[:, :, None] * ri_row.reshape(1, 1, K)
+        D0_G = d_int_0G[:, None] + d_dec_0G[:, None] * ri_row
+        ZB = lam[:, None, None] * (h_3 * D0_G[None, :, :])
+        eDB, phi1B, phi2B = _cuda_secant_phi_factors(cp, fl_pr, ZB)
+
+        x_PG = eval_F(cu_phc, cu_F_phi, cu_dec_phc, ri_row, Df_PG, D0_G)
+        F_PG = cu_F_phi.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+        Kset.post_apply1(cu_eD, cu_phc, cu_phi1, cu_F_phi, h_row, cu_a)
+        a_PG_calc = _secant_left_matmul(
+            V, eDB * _secant_left_matmul(Vi, x_PG)
+        ) + h_3 * _secant_left_matmul(V, phi1B * _secant_left_matmul(Vi, F_PG))
+        # A tail-padded slot must be bitwise frozen.  Without this mask,
+        # V @ (Vi @ x) would introduce roundoff on every h=0 tail step.
+        a_PG = cp.where(active_3, a_PG_calc, x_PG)
+        cu_a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = a_PG
+
+        eval_F(cu_a, cu_F_a, cu_dec_a, ri_row, Df_PG, D0_G)
+        Fa_PG = cu_F_a.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :]
+
+        Kset.post_apply2(
+            cu_a,
+            cu_F_a,
+            cu_F_phi,
+            cu_phi2,
+            h_row,
+            cu_phc,
+        )
+        phc_PG_calc = a_PG + h_3 * _secant_left_matmul(
+            V, phi2B * _secant_left_matmul(Vi, Fa_PG - F_PG)
+        )
+        phc_PG = cp.where(active_3, phc_PG_calc, x_PG)
+        cu_phc.reshape(n_k, N, K)[P[:, None], g_idx[None, :], :] = phc_PG
+
+        # Harvest before reset: both events may target the same slot at
+        # this boundary, and reset overwrites the state being recorded.
+        c_lo = int(cs[step])
+        c_hi = int(cs[step + 1])
+        if c_hi > c_lo:
+            cu_sol[:, cp_d[c_lo:c_hi]] = cu_phc[:, cj_d[c_lo:c_hi]]
+        r_lo = int(rs[step])
+        r_hi = int(rs[step + 1])
+        if r_hi > r_lo:
+            cu_phc[:, rj_d[r_lo:r_hi]] = cu_phi0_pp[:, rp_d[r_lo:r_hi]]
+
+    cp.cuda.Stream.null.synchronize()
+    sol_host = cp.asnumpy(cu_sol)
+
+    elapsed = time() - start
+    useful = int(np.count_nonzero(dX))
+    waste = 1.0 - useful / float(T * K) if (T * K) else 0.0
+    per_step = elapsed / float(T) if T else 0.0
+    info(
+        2,
+        f"Performance (cuda secant carousel dtype={fl_pr.__name__} K={K}, "
+        f"K_total={K_total}, T={T}): "
+        f"{1e3 * per_step:6.2f}ms/iteration "
+        f"({1e3 * per_step / float(K):6.2f}ms/iter/slot, "
+        f"waste={waste:.1%})",
+    )
     return sol_host
 
 
@@ -3497,13 +4416,23 @@ def solv_mkl_etd2_multirhs(
                 nrhs = tile_widths[t]
                 if not int_off_empty:
                     mkl_int_off.gemm_ctargs(
-                        1.0, nrhs, phc_tile_ptrs[t], n_padded,
-                        F_phi_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        phc_tile_ptrs[t],
+                        n_padded,
+                        F_phi_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
                 if not dec_off_empty:
                     mkl_dec_off.gemm_ctargs(
-                        ri, nrhs, phc_tile_ptrs[t], n_padded,
-                        F_phi_tile_ptrs[t], n_padded, beta=1.0,
+                        ri,
+                        nrhs,
+                        phc_tile_ptrs[t],
+                        n_padded,
+                        F_phi_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
 
             # a = eD[:, None] * phc + h * phi1[:, None] * F_phi  (fused C)
@@ -3516,16 +4445,28 @@ def solv_mkl_etd2_multirhs(
                 nrhs = tile_widths[t]
                 if not int_off_empty:
                     mkl_int_off.gemm_ctargs(
-                        1.0, nrhs, a_tile_ptrs[t], n_padded,
-                        F_a_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        a_tile_ptrs[t],
+                        n_padded,
+                        F_a_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
                 if not dec_off_empty:
                     mkl_dec_off.gemm_ctargs(
-                        ri, nrhs, a_tile_ptrs[t], n_padded,
-                        F_a_tile_ptrs[t], n_padded, beta=1.0,
+                        ri,
+                        nrhs,
+                        a_tile_ptrs[t],
+                        n_padded,
+                        F_a_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
 
-            _post2(n_padded, K, h, phi2_p, a_p_full, F_a_p_full, F_phi_p_full, phc_p_full)
+            _post2(
+                n_padded, K, h, phi2_p, a_p_full, F_a_p_full, F_phi_p_full, phc_p_full
+            )
 
             if grid_idcs and grid_step < len(grid_idcs) and grid_idcs[grid_step] == k:
                 grid_sol.append(np.copy(phc[:dim, :]))
@@ -3652,13 +4593,23 @@ def solv_mkl_etd2_multirhs_f32(
                 nrhs = tile_widths[t]
                 if not int_off_empty:
                     mkl_int_off.gemm_ctargs(
-                        1.0, nrhs, phc_tile_ptrs[t], n_padded,
-                        F_phi_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        phc_tile_ptrs[t],
+                        n_padded,
+                        F_phi_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
                 if not dec_off_empty:
                     mkl_dec_off.gemm_ctargs(
-                        ri, nrhs, phc_tile_ptrs[t], n_padded,
-                        F_phi_tile_ptrs[t], n_padded, beta=1.0,
+                        ri,
+                        nrhs,
+                        phc_tile_ptrs[t],
+                        n_padded,
+                        F_phi_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
 
             _post1(n_padded, K, h, eD_p, phi1_p, phc_p_full, F_phi_p_full, a_p_full)
@@ -3668,16 +4619,28 @@ def solv_mkl_etd2_multirhs_f32(
                 nrhs = tile_widths[t]
                 if not int_off_empty:
                     mkl_int_off.gemm_ctargs(
-                        1.0, nrhs, a_tile_ptrs[t], n_padded,
-                        F_a_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        a_tile_ptrs[t],
+                        n_padded,
+                        F_a_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
                 if not dec_off_empty:
                     mkl_dec_off.gemm_ctargs(
-                        ri, nrhs, a_tile_ptrs[t], n_padded,
-                        F_a_tile_ptrs[t], n_padded, beta=1.0,
+                        ri,
+                        nrhs,
+                        a_tile_ptrs[t],
+                        n_padded,
+                        F_a_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
 
-            _post2(n_padded, K, h, phi2_p, a_p_full, F_a_p_full, F_phi_p_full, phc_p_full)
+            _post2(
+                n_padded, K, h, phi2_p, a_p_full, F_a_p_full, F_phi_p_full, phc_p_full
+            )
 
             if grid_idcs and grid_step < len(grid_idcs) and grid_idcs[grid_step] == k:
                 grid_sol.append(np.copy(phc[:dim, :]))
@@ -3720,7 +4683,7 @@ def solv_mkl_etd2_carousel(
     dim = phi_initial.shape[0]
     if dX.shape != (T, K) or rho_inv.shape != (T, K):
         raise ValueError(
-            f"solv_mkl_etd2_carousel: dX/rho_inv must be (T,K)={T,K}; "
+            f"solv_mkl_etd2_carousel: dX/rho_inv must be (T,K)={T, K}; "
             f"got dX={dX.shape}, rho_inv={rho_inv.shape}"
         )
     if phi_initial.shape != (dim, K):
@@ -3750,12 +4713,16 @@ def solv_mkl_etd2_carousel(
     dec_phc = np.zeros((n_padded, K), dtype=np.float64, order="F")
     dec_a = np.zeros((n_padded, K), dtype=np.float64, order="F")
 
-    diag = {key: np.zeros((n_padded, K), dtype=np.float64, order="F")
-            for key in ("D", "hD", "eD", "phi1", "phi2", "scratch", "abs_hD")}
+    diag = {
+        key: np.zeros((n_padded, K), dtype=np.float64, order="F")
+        for key in ("D", "hD", "eD", "phi1", "phi2", "scratch", "abs_hD")
+    }
     diag["mask1"] = np.zeros((dim, K), dtype=bool, order="F")
     diag["mask2"] = np.zeros((dim, K), dtype=bool, order="F")
-    diag_view = {k: diag[k][:dim, :] for k in
-                 ("D", "hD", "eD", "phi1", "phi2", "scratch", "abs_hD")}
+    diag_view = {
+        k: diag[k][:dim, :]
+        for k in ("D", "hD", "eD", "phi1", "phi2", "scratch", "abs_hD")
+    }
     diag_view["mask1"] = diag["mask1"]
     diag_view["mask2"] = diag["mask2"]
 
@@ -3830,16 +4797,26 @@ def solv_mkl_etd2_carousel(
                 nrhs = tile_widths[t]
                 if not int_off_empty:
                     mkl_int_off.gemm_ctargs(
-                        1.0, nrhs, phc_tile_ptrs[t], n_padded,
-                        F_phi_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        phc_tile_ptrs[t],
+                        n_padded,
+                        F_phi_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
             if not dec_off_empty:
                 dec_phc.fill(0.0)
                 for t in range(n_tiles):
                     nrhs = tile_widths[t]
                     mkl_dec_off.gemm_ctargs(
-                        1.0, nrhs, phc_tile_ptrs[t], n_padded,
-                        dec_phc_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        phc_tile_ptrs[t],
+                        n_padded,
+                        dec_phc_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
                 dec_phc *= ri_K[None, :]
                 np.add(F_phi, dec_phc, out=F_phi)
@@ -3854,23 +4831,39 @@ def solv_mkl_etd2_carousel(
                 nrhs = tile_widths[t]
                 if not int_off_empty:
                     mkl_int_off.gemm_ctargs(
-                        1.0, nrhs, a_tile_ptrs[t], n_padded,
-                        F_a_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        a_tile_ptrs[t],
+                        n_padded,
+                        F_a_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
             if not dec_off_empty:
                 dec_a.fill(0.0)
                 for t in range(n_tiles):
                     nrhs = tile_widths[t]
                     mkl_dec_off.gemm_ctargs(
-                        1.0, nrhs, a_tile_ptrs[t], n_padded,
-                        dec_a_tile_ptrs[t], n_padded, beta=1.0,
+                        1.0,
+                        nrhs,
+                        a_tile_ptrs[t],
+                        n_padded,
+                        dec_a_tile_ptrs[t],
+                        n_padded,
+                        beta=1.0,
                     )
                 dec_a *= ri_K[None, :]
                 np.add(F_a, dec_a, out=F_a)
 
             _post2(
-                n_padded, K, h_K_p, phi2_p,
-                a_p_full, F_a_p_full, F_phi_p_full, phc_p_full,
+                n_padded,
+                K,
+                h_K_p,
+                phi2_p,
+                a_p_full,
+                F_a_p_full,
+                F_phi_p_full,
+                phc_p_full,
             )
 
             # Harvest pixels that just finished — BEFORE the reset.
@@ -4263,7 +5256,7 @@ def solv_spacc_etd2_carousel(
     dim = phi_initial.shape[0]
     if dX.shape != (T, K) or rho_inv.shape != (T, K):
         raise ValueError(
-            f"solv_spacc_etd2_carousel: dX/rho_inv must be (T,K)={T,K}; "
+            f"solv_spacc_etd2_carousel: dX/rho_inv must be (T,K)={T, K}; "
             f"got dX={dX.shape}, rho_inv={rho_inv.shape}"
         )
     if phi_initial.shape != (dim, K):

--- a/tests/test_2d_defaults.py
+++ b/tests/test_2d_defaults.py
@@ -14,6 +14,9 @@ kappa-window hybrid.)
 
 from types import SimpleNamespace
 
+import numpy as np
+import pytest
+
 from MCEq import config
 from MCEq.core import MCEqRun
 
@@ -32,9 +35,9 @@ def test_secant_auto_cap_clips_at_50():
     """The 'auto' cap is 90 - zenith + 5 snapped to 5-deg steps, clipped
     to [50, 75]: below ~45 deg the S_P eigenbasis is numerically
     defective (near-nilpotent coupling), so inclined zeniths run at 50."""
+
     def cap_for(theta_z):
-        stub = SimpleNamespace(
-            density_model=SimpleNamespace(theta_deg=theta_z))
+        stub = SimpleNamespace(density_model=SimpleNamespace(theta_deg=theta_z))
         return MCEqRun._secant_theta_cap_deg(stub)
 
     saved = config.secant_theta_cap_deg
@@ -43,10 +46,37 @@ def test_secant_auto_cap_clips_at_50():
         assert cap_for(0.0) == 75.0
         assert cap_for(30.0) == 65.0
         assert cap_for(45.0) == 50.0
-        assert cap_for(60.0) == 50.0   # not 35 — defective below ~45
+        assert cap_for(60.0) == 50.0  # not 35 — defective below ~45
         assert cap_for(85.0) == 50.0
         config.secant_theta_cap_deg = 62.5
-        assert cap_for(60.0) == 62.5   # explicit float passes through
+        assert cap_for(60.0) == 62.5  # explicit float passes through
+    finally:
+        config.secant_theta_cap_deg = saved
+
+
+def test_secant_auto_caps_cover_heterogeneous_fullsky_and_both_hemispheres():
+    zeniths = np.array([0, 25, 30, 35, 40, 45, 60, 85, 90, 95, 120, 180], dtype=float)
+    expected = np.array([75, 70, 65, 60, 55, 50, 50, 50, 50, 50, 50, 50])
+    stub = object.__new__(MCEqRun)
+    stub.density_model = SimpleNamespace(theta_deg=17.0)
+
+    saved = config.secant_theta_cap_deg
+    try:
+        config.secant_theta_cap_deg = "auto"
+        resolved = np.array([stub._secant_theta_cap_deg(theta_deg=z) for z in zeniths])
+        np.testing.assert_array_equal(resolved, expected)
+
+        conditions = [{"zenith_deg": float(z)} for z in zeniths]
+        np.testing.assert_array_equal(
+            stub._secant_caps_for_conditions(conditions, len(conditions)),
+            expected,
+        )
+
+        config.secant_theta_cap_deg = 62.5
+        np.testing.assert_array_equal(
+            stub._secant_caps_for_conditions(conditions, len(conditions)),
+            np.full(len(conditions), 62.5),
+        )
     finally:
         config.secant_theta_cap_deg = saved
 
@@ -61,3 +91,57 @@ def test_secant_mode_resolution():
     # Explicit False: off everywhere.
     assert _mode_for(False, True) == "off"
     assert _mode_for(False, False) == "off"
+
+
+def test_batch_secant_backend_semantics_never_downgrade():
+    stub = object.__new__(MCEqRun)
+    stub._mceq_db = SimpleNamespace(is_2d=True)
+    stub._int_m_stack = None
+    stub._em_rho_grid = None
+
+    saved_flag = config.secant_theta_transport
+    saved_kernel = config.kernel_config
+    try:
+        for flag in ("auto", True):
+            config.secant_theta_transport = flag
+            config.kernel_config = "numpy_etd2"
+            assert stub._require_batch_secant_supported("test") is True
+            config.kernel_config = "cuda_etd2"
+            assert stub._require_batch_secant_supported("test") is True
+
+            for unsupported in ("mkl_etd2", "accelerate_etd2"):
+                config.kernel_config = unsupported
+                with pytest.raises(NotImplementedError, match="No paraxial downgrade"):
+                    stub._require_batch_secant_supported("test")
+
+        config.secant_theta_transport = False
+        config.kernel_config = "accelerate_etd2"
+        assert stub._require_batch_secant_supported("test") is False
+
+        # A 1-D database always resolves off, independent of the requested
+        # flag and backend.
+        stub._mceq_db = SimpleNamespace(is_2d=False)
+        config.secant_theta_transport = True
+        config.kernel_config = "mkl_etd2"
+        assert stub._require_batch_secant_supported("test") is False
+    finally:
+        config.secant_theta_transport = saved_flag
+        config.kernel_config = saved_kernel
+
+
+def test_batch_secant_rho_stack_reports_clear_error():
+    stub = object.__new__(MCEqRun)
+    stub._mceq_db = SimpleNamespace(is_2d=True)
+    stub._int_m_stack = [object()]
+    stub._em_rho_grid = np.array([1.0])
+
+    saved_flag = config.secant_theta_transport
+    saved_kernel = config.kernel_config
+    try:
+        config.secant_theta_transport = "auto"
+        config.kernel_config = "numpy_etd2"
+        with pytest.raises(NotImplementedError, match="rho-stack"):
+            stub._require_batch_secant_supported("test")
+    finally:
+        config.secant_theta_transport = saved_flag
+        config.kernel_config = saved_kernel

--- a/tests/test_secant_fullsky_2d.py
+++ b/tests/test_secant_fullsky_2d.py
@@ -1,0 +1,280 @@
+"""Optional production-DB regression for secant full-sky transport.
+
+Set ``MCEQ_SECANT_2D_REGRESSION=1`` and ``MCEQ_SECANT_2D_DB=/path/to/db.h5``
+to run it.  The synthetic tests in :mod:`test_secant_multirhs` are the fast CI
+coverage; this gate checks real particle indexing, all 48 kappa modes, both
+hemispheres, auto/fixed caps, and the exact-J1 observable.
+"""
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.interpolate import CubicSpline
+from scipy.special import j1
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("MCEQ_SECANT_2D_REGRESSION") != "1",
+    reason="set MCEQ_SECANT_2D_REGRESSION=1 for the production 48-mode gate",
+)
+
+
+ZENITHS = np.array([0, 25, 30, 35, 40, 45, 60, 85, 90, 95, 120, 180], dtype=float)
+EXPECTED_CAPS = np.array([75, 70, 65, 60, 55, 50, 50, 50, 50, 50, 50, 50])
+
+
+def _j1_integral(amplitudes, k_grid):
+    theta_max = np.pi / 2.0
+    k_fine = np.linspace(k_grid[0], k_grid[-1], 10001)
+    dk = np.diff(k_fine)
+    trap = np.empty_like(k_fine)
+    trap[0] = 0.5 * dk[0]
+    trap[-1] = 0.5 * dk[-1]
+    trap[1:-1] = 0.5 * (dk[:-1] + dk[1:])
+    weights = theta_max * j1(k_fine * theta_max) * trap
+    fine = CubicSpline(k_grid, amplitudes, axis=0)(k_fine)
+    return np.tensordot(weights, fine, axes=(0, 0))
+
+
+def _particle_modes(mceq, state, keys):
+    n_k = int(mceq._mceq_db.n_k)
+    K = state.shape[1]
+    modes = state.reshape(n_k, mceq.dim_states, K)
+    out = np.zeros((n_k, len(mceq.e_grid), K))
+    for key in keys:
+        first = mceq.pman.pdg2mceqidx[key] * len(mceq.e_grid)
+        out += modes[:, first : first + len(mceq.e_grid), :]
+    return out
+
+
+def _single_axis_to_fraction(mceq, phi0, fraction, *, eps, dX_max):
+    """Run the production single-axis kernel only to a saved endpoint.
+
+    ``solve(int_grid=[endpoint])`` records at the requested depth but then
+    propagates through ``max_X``. Truncate that exact integration path before
+    dispatch so this optional real-matrix test stays bounded while retaining an
+    independent single-axis secant kernel as its reference.
+    """
+    endpoint = fraction * float(mceq.density_model.max_X)
+    mceq._calculate_integration_path(
+        [endpoint],
+        "X",
+        eps=eps,
+        dX_max=dX_max,
+    )
+    path = mceq._truncate_path_at_last_snapshot(
+        mceq.integration_path, "test_secant_fullsky_2d"
+    )
+    mceq.integration_path = path
+    mceq._phi0[:] = phi0
+    mceq.solve(skip_integration_path=True)
+    return mceq._solution.copy(), path[0]
+
+
+def test_real_48mode_fullsky_auto_fixed_caps_and_per_rhs_primaries(monkeypatch):
+    db = Path(os.environ.get("MCEQ_SECANT_2D_DB", ""))
+    if not db.is_file():
+        pytest.skip(f"MCEQ_SECANT_2D_DB is not a file: {db}")
+
+    import crflux.models as crf
+
+    from MCEq import config
+    from MCEq.core import MCEqRun
+    from MCEq.geometry.density_profiles import MSIS00IceCubeCentered
+
+    kernel = os.environ.get("MCEQ_SECANT_2D_KERNEL", "numpy_etd2")
+    if kernel not in ("numpy_etd2", "cuda_etd2"):
+        pytest.fail(
+            f"MCEQ_SECANT_2D_KERNEL must be numpy_etd2 or cuda_etd2, got {kernel!r}"
+        )
+    if kernel == "cuda_etd2":
+        try:
+            import cupy as cp
+
+            if cp.cuda.runtime.getDeviceCount() < 1:
+                pytest.skip("CUDA regression requested but no device is visible")
+        except Exception as exc:
+            pytest.skip(f"CUDA regression requested but unavailable: {exc}")
+
+    monkeypatch.setattr(config, "data_dir", db.resolve().parent)
+    monkeypatch.setattr(config, "mceq_db_fname", db.name)
+    monkeypatch.setattr(config, "kernel_config", kernel)
+    monkeypatch.setattr(config, "cuda_fp_precision", 64)
+    monkeypatch.setattr(config, "e_min", 0.1)
+    monkeypatch.setattr(config, "e_max", 100.0)
+    monkeypatch.setattr(config, "debug_level", 0)
+    monkeypatch.setattr(config, "secant_theta_transport", "auto")
+    monkeypatch.setattr(config, "secant_theta_cap_deg", "auto")
+    monkeypatch.setattr(config, "secant_theta_e_gate", 31.6)
+    monkeypatch.setattr(config, "muon_multiple_scattering", True)
+    monkeypatch.setattr(
+        config,
+        "low_energy_extension",
+        dict(
+            config.low_energy_extension,
+            model="FLUKA20251",
+            he_le_transition=80,
+            he_le_trwidth=0.3,
+        ),
+    )
+
+    mceq = MCEqRun(
+        interaction_model="SIBYLL23E",
+        density_model=MSIS00IceCubeCentered("SouthPole", "January"),
+        primary_model=(crf.GaisserHonda, None),
+        theta_deg=0.0,
+    )
+    try:
+        assert mceq._mceq_db.is_2d and mceq._mceq_db.n_k == 48
+        base = mceq._phi0.copy()
+        phi0 = np.broadcast_to(base[:, None], (mceq.dim_states, len(ZENITHS))).copy()
+        # Cutoff-like, deliberately distinct primary columns. The real
+        # production gate uses gtracr-derived states; these masks make
+        # cross-talk/order failures obvious without invoking gtracr here.
+        initial_3 = phi0.reshape(-1, len(mceq.e_grid), len(ZENITHS))
+        for rhs, threshold in enumerate(np.linspace(0.1, 8.0, len(ZENITHS))):
+            initial_3[:, mceq.e_grid < threshold, rhs] = 0.0
+            initial_3[:, :, rhs] *= 0.7 + 0.05 * rhs
+
+        solve_kwargs = dict(
+            carousel_K=4,
+            eps=0.02,
+            dX_max=2.0,
+            # Keep this optional CPU gate bounded while retaining the real
+            # 48-mode matrices and distinct atmospheric paths. The full-depth
+            # production gate below the test suite uses 0.9999 and dX_max=0.4.
+            X_stop_fraction=0.01,
+        )
+        result = mceq.solve_fullsky(
+            ZENITHS,
+            phi0=phi0,
+            geomagnetic_cutoff=False,
+            **solve_kwargs,
+        )
+        batched = np.asarray(result.sol)
+        assert batched.shape == (48 * mceq.dim_states, len(ZENITHS))
+        np.testing.assert_array_equal(
+            np.array([mceq._secant_theta_cap_deg(z) for z in ZENITHS]),
+            EXPECTED_CAPS,
+        )
+        np.testing.assert_array_equal(
+            result.pixel_index,
+            np.column_stack(
+                (
+                    np.arange(len(ZENITHS), dtype=np.int32),
+                    np.zeros(len(ZENITHS), dtype=np.int32),
+                )
+            ),
+        )
+
+        serial = np.empty_like(batched)
+        serial_nsteps = []
+        for rhs, zenith in enumerate(ZENITHS):
+            mceq.set_zenith_azimuth(float(zenith), None)
+            serial[:, rhs], nsteps = _single_axis_to_fraction(
+                mceq,
+                phi0[:, rhs],
+                solve_kwargs["X_stop_fraction"],
+                eps=solve_kwargs["eps"],
+                dX_max=solve_kwargs["dX_max"],
+            )
+            serial_nsteps.append(nsteps)
+        np.testing.assert_array_equal(result.nsteps_per_col, serial_nsteps)
+
+        species = {
+            "proton": ((2212, 0),),
+            "muon": tuple(
+                key
+                for key in ((13, 0), (13, -1), (13, 1))
+                if key in mceq.pman.pdg2mceqidx
+            ),
+            "numu": ((14, 0), (-14, 0)),
+            "nue": ((12, 0), (-12, 0)),
+        }
+        for keys in species.values():
+            batch_modes = _particle_modes(mceq, batched, keys)
+            serial_modes = _particle_modes(mceq, serial, keys)
+            np.testing.assert_allclose(
+                batch_modes, serial_modes, rtol=3e-11, atol=3e-14
+            )
+            np.testing.assert_allclose(
+                _j1_integral(batch_modes, mceq._mceq_db.k_grid),
+                _j1_integral(serial_modes, mceq._mceq_db.k_grid),
+                rtol=3e-10,
+                atol=3e-13,
+            )
+
+        # A fixed cap collapses every column onto one operator and still
+        # preserves each atmosphere path/initial state.
+        config.secant_theta_cap_deg = 65.0
+        fixed_axes = np.array([0.0, 60.0, 90.0])
+        fixed_phi0 = phi0[:, [0, 6, 8]]
+        fixed = mceq.solve_fullsky(
+            fixed_axes,
+            phi0=fixed_phi0,
+            geomagnetic_cutoff=False,
+            **solve_kwargs,
+        ).sol
+        fixed_serial = []
+        for rhs, zenith in enumerate(fixed_axes):
+            mceq.set_zenith_azimuth(float(zenith), None)
+            column, _ = _single_axis_to_fraction(
+                mceq,
+                fixed_phi0[:, rhs],
+                solve_kwargs["X_stop_fraction"],
+                eps=solve_kwargs["eps"],
+                dX_max=solve_kwargs["dX_max"],
+            )
+            fixed_serial.append(column)
+        np.testing.assert_allclose(
+            fixed, np.stack(fixed_serial, axis=1), rtol=3e-11, atol=3e-14
+        )
+        if kernel == "cuda_etd2":
+            cache = mceq._cuda_etd2_multirhs_cache
+            contexts = [entry["ctx"] for entry in cache.values()]
+            assert {ctx.K for ctx in contexts}.issuperset({1, 3, 4})
+            anchor = contexts[0]
+            for ctx in contexts[1:]:
+                assert ctx.cu_int_off is anchor.cu_int_off
+                assert ctx.cu_dec_off is anchor.cu_dec_off
+                assert ctx.cu_d_int is anchor.cu_d_int
+                assert ctx.cu_d_dec is anchor.cu_d_dec
+
+        # Explicit False must stay on the pre-existing paraxial carousel.
+        # Compare it with independent single-axis paraxial solves on a real
+        # 48-mode matrix and fail immediately if a secant operator is built.
+        config.secant_theta_transport = False
+        monkeypatch.setattr(
+            mceq,
+            "_build_secant_ops",
+            lambda *args, **kwargs: pytest.fail(
+                "secant operator built with secant_theta_transport=False"
+            ),
+        )
+        assert mceq._require_batch_secant_supported("test") is False
+        paraxial = mceq.solve_fullsky(
+            fixed_axes,
+            phi0=fixed_phi0,
+            geomagnetic_cutoff=False,
+            **solve_kwargs,
+        ).sol
+        paraxial_serial = []
+        for rhs, zenith in enumerate(fixed_axes):
+            mceq.set_zenith_azimuth(float(zenith), None)
+            column, _ = _single_axis_to_fraction(
+                mceq,
+                fixed_phi0[:, rhs],
+                solve_kwargs["X_stop_fraction"],
+                eps=solve_kwargs["eps"],
+                dX_max=solve_kwargs["dX_max"],
+            )
+            paraxial_serial.append(column)
+        np.testing.assert_allclose(
+            paraxial,
+            np.stack(paraxial_serial, axis=1),
+            rtol=3e-11,
+            atol=3e-14,
+        )
+    finally:
+        mceq.close()

--- a/tests/test_secant_multirhs.py
+++ b/tests/test_secant_multirhs.py
@@ -1,0 +1,307 @@
+"""Focused closure tests for secant-coupled multi-RHS ETD2 kernels.
+
+The fixture deliberately has 48 logical Hankel modes while keeping the
+per-mode state tiny.  It therefore exercises the production tensor layout,
+all modes, independent initial columns, carousel resets, and an exact-J1
+theta-integrated readout without requiring the minutes-scale fitted operator
+or the external production database.
+"""
+
+import numpy as np
+import pytest
+import scipy.sparse as sp
+from scipy.interpolate import CubicSpline
+from scipy.special import j1
+
+from MCEq.solvers import (
+    CudaEtd2Context,
+    CudaEtd2MultiRHSContext,
+    _etd_split_cache,
+    compile_carousel_schedule,
+    schedule_lpt,
+    solv_cuda_etd2_secant,
+    solv_cuda_etd2_secant_carousel,
+    solv_cuda_etd2_secant_multirhs,
+    solv_numpy_etd2_secant,
+    solv_numpy_etd2_secant_carousel,
+    solv_numpy_etd2_secant_multirhs,
+)
+
+
+def _secant_ops(n_k, N, scale=1.0):
+    P = np.arange(12, dtype=np.int64)
+    distance = np.abs(P[:, None] - P[None, :])
+    T_PP = scale * 0.025 * np.exp(-distance / 2.5)
+    T_P = np.zeros((len(P), n_k), dtype=np.float64)
+    T_P[:, P] = T_PP
+    # One-way support from uncoupled modes exercises the T_P[:, ~P] leg.
+    T_P[:, 20] = scale * np.linspace(0.002, 0.0002, len(P))
+    T_P[:, 35] = scale * np.linspace(-0.0001, 0.001, len(P))
+    lam, V = np.linalg.eigh(np.eye(len(P)) + T_PP)
+    return {
+        "P": P,
+        "T_P": T_P,
+        "T_PP": T_PP,
+        "V": V,
+        "Vi": V.T,
+        "lam": lam,
+        # Conceptual columns: hadron, muon, numu, nue.
+        "gate_idx": np.array([0, 2, 4, 5], dtype=np.int64),
+        "n_k": n_k,
+    }
+
+
+@pytest.fixture
+def secant_48mode_problem():
+    rng = np.random.default_rng(20260825)
+    n_k, N, K = 48, 6, 4
+    dim = n_k * N
+    per_mode_int = []
+    per_mode_dec = []
+    for mode in range(n_k):
+        int_block = np.triu(rng.uniform(0.0, 0.012, (N, N)), 1)
+        int_block -= np.diag(rng.uniform(0.05, 0.13, N) + mode * 2e-5)
+        dec_block = np.triu(rng.uniform(0.0, 0.006, (N, N)), 1)
+        dec_block -= np.diag(rng.uniform(0.01, 0.035, N))
+        per_mode_int.append(sp.csr_matrix(int_block))
+        per_mode_dec.append(sp.csr_matrix(dec_block))
+    int_m = sp.block_diag(per_mode_int, format="csr")
+    dec_m = sp.block_diag(per_mode_dec, format="csr")
+
+    phi0 = rng.uniform(0.05, 1.0, (dim, K))
+    # Distinct primary columns, including a zero/cutoff-like state.  Tiling
+    # each per-mode base vector also mirrors a collimated 2-D primary.
+    base = rng.uniform(0.1, 1.2, (N, K))
+    base[:, 1] *= np.linspace(0.2, 1.0, N)
+    base[:, 2] = 0.0
+    base[:, 3] *= 1.7
+    phi0[:] = np.tile(base, (n_k, 1))
+
+    dX = np.array([0.08, 0.13, 0.05, 0.17, 0.09, 0.11])
+    rho_inv = np.array([1.1, 0.8, 1.3, 0.7, 0.95, 1.05])
+    paths = [
+        (6, dX.copy(), rho_inv.copy(), []),
+        (3, dX[:3].copy(), rho_inv[:3].copy(), []),
+        (5, dX[:5].copy(), rho_inv[:5].copy(), []),
+        (2, dX[:2].copy(), rho_inv[:2].copy(), []),
+    ]
+    return {
+        "n_k": n_k,
+        "N": N,
+        "K": K,
+        "dim": dim,
+        "k_grid": np.linspace(0.0, 80.0, n_k),
+        "int_m": int_m,
+        "dec_m": dec_m,
+        "phi0": phi0,
+        "dX": dX,
+        "rho_inv": rho_inv,
+        "paths": paths,
+    }
+
+
+def _single_numpy_columns(problem, paths, sec_ops):
+    out = []
+    for rhs, path in enumerate(paths):
+        nsteps, dX, rho_inv, _ = path
+        col, _ = solv_numpy_etd2_secant(
+            nsteps,
+            dX,
+            rho_inv,
+            problem["int_m"],
+            problem["dec_m"],
+            problem["phi0"][:, rhs],
+            [],
+            sec_ops,
+        )
+        out.append(col)
+    return np.stack(out, axis=1)
+
+
+def _theta_integrated(state, k_grid, n_k, N):
+    """Exact-J1 observable for every conceptual species/RHS column."""
+    modes = state.reshape(n_k, N, -1)
+    theta_max = np.pi / 2.0
+    k_fine = np.linspace(k_grid[0], k_grid[-1], 2001)
+    dk = np.diff(k_fine)
+    trap = np.empty_like(k_fine)
+    trap[0] = 0.5 * dk[0]
+    trap[-1] = 0.5 * dk[-1]
+    trap[1:-1] = 0.5 * (dk[:-1] + dk[1:])
+    weights = theta_max * j1(k_fine * theta_max) * trap
+    fine = CubicSpline(k_grid, modes, axis=0)(k_fine)
+    return np.tensordot(weights, fine, axes=(0, 0))
+
+
+@pytest.mark.parametrize("operator_scale", [0.7, 1.0])
+def test_numpy_secant_multirhs_matches_repeated_single_all_modes(
+    secant_48mode_problem, operator_scale
+):
+    p = secant_48mode_problem
+    ops = _secant_ops(p["n_k"], p["N"], operator_scale)
+    snapshots = [1, 5]
+    # Homogeneous closure means genuinely identical RHS columns. Distinct
+    # per-RHS primaries and cross-talk/order are exercised by the carousel
+    # test below.
+    identical_phi0 = np.repeat(p["phi0"][:, :1], p["K"], axis=1)
+    batched, batched_grid = solv_numpy_etd2_secant_multirhs(
+        len(p["dX"]),
+        p["dX"],
+        p["rho_inv"],
+        p["int_m"],
+        p["dec_m"],
+        identical_phi0,
+        snapshots,
+        ops,
+    )
+
+    reference = []
+    reference_grid = []
+    for rhs in range(p["K"]):
+        col, grid = solv_numpy_etd2_secant(
+            len(p["dX"]),
+            p["dX"],
+            p["rho_inv"],
+            p["int_m"],
+            p["dec_m"],
+            identical_phi0[:, rhs],
+            snapshots,
+            ops,
+        )
+        reference.append(col)
+        reference_grid.append(grid)
+    reference = np.stack(reference, axis=1)
+    reference_grid = np.stack(reference_grid, axis=2)
+
+    np.testing.assert_allclose(batched, reference, rtol=3e-14, atol=3e-14)
+    np.testing.assert_allclose(batched_grid, reference_grid, rtol=3e-14, atol=3e-14)
+    np.testing.assert_allclose(
+        _theta_integrated(batched, p["k_grid"], p["n_k"], p["N"]),
+        _theta_integrated(reference, p["k_grid"], p["n_k"], p["N"]),
+        rtol=5e-13,
+        atol=5e-13,
+    )
+
+
+def test_numpy_secant_carousel_matches_independent_paths_and_primary_states(
+    secant_48mode_problem,
+):
+    p = secant_48mode_problem
+    ops = _secant_ops(p["n_k"], p["N"])
+    reference = _single_numpy_columns(p, p["paths"], ops)
+
+    slots, T = schedule_lpt([path[0] for path in p["paths"]], 2)
+    dX_c, rho_c, phi_initial, schedule = compile_carousel_schedule(
+        p["paths"], slots, T, p["dim"], p["phi0"]
+    )
+    carousel = solv_numpy_etd2_secant_carousel(
+        p["int_m"],
+        p["dec_m"],
+        dX_c,
+        rho_c,
+        phi_initial,
+        schedule,
+        p["phi0"],
+        ops,
+    )
+
+    np.testing.assert_allclose(carousel, reference, rtol=3e-14, atol=3e-14)
+    # The zero/cutoff-like input remains isolated, and harvest order is the
+    # original RHS order rather than LPT slot order.
+    assert np.count_nonzero(carousel[:, 2]) == 0
+    assert np.count_nonzero(carousel[:, 0]) > 0
+    assert np.count_nonzero(carousel[:, 1]) > 0
+    assert np.count_nonzero(carousel[:, 3]) > 0
+    np.testing.assert_allclose(
+        _theta_integrated(carousel, p["k_grid"], p["n_k"], p["N"]),
+        _theta_integrated(reference, p["k_grid"], p["n_k"], p["N"]),
+        rtol=5e-13,
+        atol=5e-13,
+    )
+
+
+def _cuda_available():
+    try:
+        import cupy as cp
+
+        return cp.cuda.runtime.getDeviceCount() > 0
+    except Exception:
+        return False
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA/CuPy not available")
+def test_cuda_secant_multirhs_and_carousel_backend_parity(secant_48mode_problem):
+    p = secant_48mode_problem
+    ops = _secant_ops(p["n_k"], p["N"])
+    d_int, d_dec, int_off, dec_off = _etd_split_cache(p["int_m"], p["dec_m"])
+    multi_ctx = CudaEtd2MultiRHSContext(
+        int_off, dec_off, d_int, d_dec, K=p["K"], device_id=0, fp_precision=64
+    )
+    width_two_ctx = CudaEtd2MultiRHSContext(
+        int_off,
+        dec_off,
+        d_int,
+        d_dec,
+        K=2,
+        device_id=0,
+        fp_precision=64,
+        shared_static=multi_ctx,
+    )
+    assert width_two_ctx.cu_int_off is multi_ctx.cu_int_off
+    assert width_two_ctx.cu_dec_off is multi_ctx.cu_dec_off
+    assert width_two_ctx.cu_d_int is multi_ctx.cu_d_int
+    assert width_two_ctx.cu_d_dec is multi_ctx.cu_d_dec
+    assert width_two_ctx.cu_phc is not multi_ctx.cu_phc
+    cuda_shared, _ = solv_cuda_etd2_secant_multirhs(
+        len(p["dX"]),
+        p["dX"],
+        p["rho_inv"],
+        multi_ctx,
+        p["phi0"],
+        [],
+        ops,
+    )
+    numpy_shared, _ = solv_numpy_etd2_secant_multirhs(
+        len(p["dX"]),
+        p["dX"],
+        p["rho_inv"],
+        p["int_m"],
+        p["dec_m"],
+        p["phi0"],
+        [],
+        ops,
+    )
+    np.testing.assert_allclose(cuda_shared, numpy_shared, rtol=2e-11, atol=2e-12)
+
+    slots, T = schedule_lpt([path[0] for path in p["paths"]], p["K"])
+    dX_c, rho_c, phi_initial, schedule = compile_carousel_schedule(
+        p["paths"], slots, T, p["dim"], p["phi0"]
+    )
+    cuda_carousel = solv_cuda_etd2_secant_carousel(
+        multi_ctx, dX_c, rho_c, phi_initial, schedule, p["phi0"], ops
+    )
+    numpy_reference = _single_numpy_columns(p, p["paths"], ops)
+    np.testing.assert_allclose(cuda_carousel, numpy_reference, rtol=2e-11, atol=2e-12)
+
+    single_ctx = CudaEtd2Context(
+        int_off, dec_off, d_int, d_dec, device_id=0, fp_precision=64
+    )
+    cuda_single = []
+    for rhs, path in enumerate(p["paths"]):
+        nsteps, dX, rho_inv, _ = path
+        col, _ = solv_cuda_etd2_secant(
+            nsteps,
+            dX,
+            rho_inv,
+            single_ctx,
+            p["phi0"][:, rhs],
+            [],
+            ops,
+        )
+        cuda_single.append(col)
+    np.testing.assert_allclose(
+        cuda_carousel,
+        np.stack(cuda_single, axis=1),
+        rtol=2e-11,
+        atol=2e-12,
+    )


### PR DESCRIPTION
## Summary

- extend strict secant-theta transport through solve_batch, solve_multirhs, and the full-sky LPT carousel on NumPy and CUDA
- group heterogeneous full-sky columns by resolved secant cap while preserving per-column paths, primary states, and output order
- cache complete host operator sets and CUDA uploads, and share immutable CUDA sparse matrices across pipeline widths
- add exact endpoint truncation for production checkpoint comparisons and explicit guards against unsupported MKL, Accelerate, and rho-stack combinations
- add focused 48-mode synthetic coverage plus an opt-in production-database regression

## Validation

- focused secant/defaults: 8 passed, 2 skipped
- solver suite excluding CUDA selection: 48 passed, 11 skipped, 8 deselected
- 2D regression suite without an exposed GPU: 5 passed, 2 skipped, 1 deselected
- ruff format check: clean
- CUDA fp64 production comparison: all 37 South-Pole columns and all 48 kappa modes close; maximum amplitude residual 4.60e-12 and exact-J1 flavour ratios agree within 5.59e-13

The current environment has CuPy installed but exposes no CUDA device, so its import-only skip predicate attempts one CUDA regression and fails with cudaErrorNoDevice. The focused CUDA synthetic and real 48-mode production gates were completed on the GPU host before this commit.