### PR TITLE
Default to the v1.4.2 database

### DIFF
--- a/changes/164.bugfix.md
+++ b/changes/164.bugfix.md
@@ -1,1 +1,1 @@
-Fix Windows CI flake when the full database is downloaded concurrently by pytest-xdist workers. Group all tests that switch to ``mceq_db_lext_dpm193_v140.h5`` under ``xdist_group("full_db")`` and run the suite with ``--dist loadgroup`` so the download happens on a single worker.
+Fix Windows CI flake when the full database is downloaded concurrently by pytest-xdist workers. Group all tests that switch to ``mceq_db_lext_dpm193_v142.h5`` under ``xdist_group("full_db")`` and run the suite with ``--dist loadgroup`` so the download happens on a single worker.

--- a/changes/164.bugfix.md
+++ b/changes/164.bugfix.md
@@ -1,1 +1,1 @@
-Fix Windows CI flake when the full database is downloaded concurrently by pytest-xdist workers. Group all tests that switch to ``mceq_db_lext_dpm193_v142.h5`` under ``xdist_group("full_db")`` and run the suite with ``--dist loadgroup`` so the download happens on a single worker.
+Fix Windows CI flake when the full database is downloaded concurrently by pytest-xdist workers. Group all tests that switch to ``mceq_db_lext_dpm193_v140.h5`` under ``xdist_group("full_db")`` and run the suite with ``--dist loadgroup`` so the download happens on a single worker.

--- a/changes/185.bugfix.md
+++ b/changes/185.bugfix.md
@@ -1,0 +1,7 @@
+Switched the default database to ``mceq_db_lext_dpm193_v142.h5``. The v1.4.0
+database was withdrawn from the release assets after the v1.4.2 bugfix release
+(neutron projectiles were simulated as protons in the v1.4.0/v1.4.1 databases),
+so downloads of the previous default returned a 404 on every fresh install. The
+stored sha256 checksum, which had gone stale, now matches the published v1.4.2
+file, and ``ensure_db_available`` removes both ``mceq_db_lext_dpm193_v140.h5``
+and ``mceq_db_lext_dpm191.h5`` on upgrade so no orphaned database is left behind.

--- a/src/MCEq/config.py
+++ b/src/MCEq/config.py
@@ -26,7 +26,7 @@ print_module = False
 data_dir = pathlib.Path(base_path) / "data"
 
 #: File name of the MCEq database
-mceq_db_fname = "mceq_db_lext_dpm193_v140.h5"
+mceq_db_fname = "mceq_db_lext_dpm193_v142.h5"
 
 #: File name of the MCEq database
 em_db_fname = "mceq_db_EM_Tsai-Max_Z7.31.h5"
@@ -635,8 +635,8 @@ def _download_file(url, outfile):
 base_url = "https://github.com/afedynitch/MCEq/releases/download/"
 release_tag = "builds_on_azure/"
 # sha256 checksum of the default database file
-# https://github.com/afedynitch/MCEq/releases/download/builds_on_azure/mceq_db_lext_dpm191_v12.h5
-file_checksum = "5da415e9bcf81926b1061d5792d75cb3aceb9de173beccb4695fd3909a0bfdd0"
+# https://github.com/afedynitch/MCEq/releases/download/builds_on_azure/mceq_db_lext_dpm193_v142.h5
+file_checksum = "247f40203436c69431db4d393316940636badb2c231f68d51870fb49bf476946"
 
 
 def ensure_db_available():
@@ -656,7 +656,7 @@ def ensure_db_available():
     if filepath.exists():
         is_complete = (
             FileIntegrityCheck(filepath, file_checksum).succeeded()
-            if mceq_db_fname == "mceq_db_lext_dpm193_v140.h5"
+            if mceq_db_fname == "mceq_db_lext_dpm193_v142.h5"
             else True
         )
     else:
@@ -668,7 +668,8 @@ def ensure_db_available():
             print(_url)
         _download_file(_url, filepath)
 
-    old_db = data_dir / "mceq_db_lext_dpm191.h5"
-    if old_db.exists():
-        print(f"Removing previous database {old_db.name}.")
-        os.unlink(old_db)
+    for old_name in ("mceq_db_lext_dpm193_v140.h5", "mceq_db_lext_dpm191.h5"):
+        old_db = data_dir / old_name
+        if old_db.exists():
+            print(f"Removing previous database {old_db.name}.")
+            os.unlink(old_db)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
 
+import pytest
+
 import MCEq.config as cfg
 
-DEFAULT_DB = "mceq_db_lext_dpm193_v140.h5"
+DEFAULT_DB = "mceq_db_lext_dpm193_v142.h5"
 CUSTOM_DB = "mceq_db_v140reduced_compact.h5"
-OLD_DB = "mceq_db_lext_dpm191.h5"
+OLD_DBS = ("mceq_db_lext_dpm193_v140.h5", "mceq_db_lext_dpm191.h5")
 
 
 # ---------------------------------------------------------------------------
@@ -88,9 +90,10 @@ def test_downloads_missing_custom_db(tmp_path, monkeypatch):
     )
 
 
-def test_removes_old_db(tmp_path, monkeypatch):
+@pytest.mark.parametrize("old_name", OLD_DBS)
+def test_removes_old_db(tmp_path, monkeypatch, old_name):
     (tmp_path / CUSTOM_DB).write_bytes(b"fake")
-    old = tmp_path / OLD_DB
+    old = tmp_path / old_name
     old.write_bytes(b"old")
     monkeypatch.setattr(cfg, "data_dir", tmp_path)
     monkeypatch.setattr(cfg, "mceq_db_fname", CUSTOM_DB)

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1026,7 +1026,7 @@ def mceq_sib21_full_db():
 
     saved_db = config.mceq_db_fname
     saved_disabled = list(config.adv_set.get("disabled_particles", []))
-    config.mceq_db_fname = "mceq_db_lext_dpm193_v140.h5"
+    config.mceq_db_fname = "mceq_db_lext_dpm193_v142.h5"
     config.adv_set["disabled_particles"] = []
     try:
         if config.has_mkl:
@@ -1228,7 +1228,7 @@ def test_solv_mkl_etd2_stable_at_high_zenith():
     saved_kernel = config.kernel_config
     saved_db = config.mceq_db_fname
     config.adv_set["disabled_particles"] = [11, -11]
-    config.mceq_db_fname = "mceq_db_lext_dpm193_v140.h5"
+    config.mceq_db_fname = "mceq_db_lext_dpm193_v142.h5"
     try:
         mceq = MCEqRun(
             interaction_model="SIBYLL21",
@@ -1308,7 +1308,7 @@ def test_solv_cuda_etd2_stable_at_high_zenith():
     saved_kernel = config.kernel_config
     saved_db = config.mceq_db_fname
     config.adv_set["disabled_particles"] = [11, -11]
-    config.mceq_db_fname = "mceq_db_lext_dpm193_v140.h5"
+    config.mceq_db_fname = "mceq_db_lext_dpm193_v142.h5"
     try:
         mceq = MCEqRun(
             interaction_model="SIBYLL21",


### PR DESCRIPTION
The v1.4.0 database was withdrawn from the release assets after the v1.4.2 bugfix release. 

This PR replaces v140 with v142 db.